### PR TITLE
Refactor API wrapper usage

### DIFF
--- a/src/hooks/api/apiWrapper.ts
+++ b/src/hooks/api/apiWrapper.ts
@@ -1,0 +1,26 @@
+import { handleApiCall } from '@/tech/handleApiCall'
+import { handleServerApiCall } from '@/tech/fetch/handleServerApiCall'
+
+export type Mapping = Record<string, (data: any) => any>
+
+const baseWrap = <T extends Record<string, any>>(api: T, mapping: Mapping = {}, handler: (p: Promise<any>) => Promise<any>) => {
+    const wrapped: Record<string, any> = {}
+    for (const key of Object.keys(api)) {
+        const fn = (api as any)[key]
+        if (typeof fn === 'function') {
+            wrapped[key] = (...args: any[]) => {
+                const promise = fn.apply(api, args)
+                const call = handler(promise as any)
+                const mapFn = mapping[key]
+                return mapFn ? call.then(mapFn) : call
+            }
+        }
+    }
+    return wrapped as T
+}
+
+export const wrapApi = <T extends Record<string, any>>(api: T, mapping: Mapping = {}) =>
+    baseWrap(api, mapping, handleApiCall)
+
+export const wrapServerApi = <T extends Record<string, any>>(api: T, mapping: Mapping = {}) =>
+    baseWrap(api, mapping, handleServerApiCall)

--- a/src/hooks/api/tech.ts
+++ b/src/hooks/api/tech.ts
@@ -1,8 +1,8 @@
 import {
-	AnalyticsApi,
-	AuthApi,
-	BridgeApi,
-	Configuration,
+        AnalyticsApi,
+        AuthApi,
+        BridgeApi,
+        Configuration,
 	ImagesApi,
 	MailApi,
 	MessengerApi,
@@ -30,43 +30,114 @@ import {
 	TeamMembersApi,
 	TeamPlaylistsApi,
 	TeamSongNotesApi,
-	TeamStatisticsApi,
+        TeamStatisticsApi,
 } from '@/api/generated'
+import {
+        mapPlaylistDataOutDtoToPlaylistDto,
+        mapPlaylistItemOutDtoApiToPlaylistItemDto,
+} from '@/api/dtos/playlist/playlist.map'
+import {
+        mapSearchSongPacksApiToDto,
+        mapBasicVariantPackApiToDto,
+} from '@/api/dtos/song'
+import { PlaylistGuid } from '@/interfaces/playlist/playlist.types'
+import { wrapApi, wrapServerApi } from './apiWrapper'
 
 export type ApiClasses = ReturnType<typeof getApiClasses>
 
-export const getApiClasses = (apiConfiguration: Configuration) => ({
-	playlistGettingApi: new PlaylistGettingApi(apiConfiguration),
-	playlistEditingApi: new PlaylistEditingApi(apiConfiguration),
-	songGettingApi: new SongGettingApi(apiConfiguration),
-	songSearchingApi: new SongSearchingApi(apiConfiguration),
-	songAddingApi: new SongAddingApi(apiConfiguration),
-	songEditingApi: new SongEditingApi(apiConfiguration),
-	songDeletingApi: new SongDeletingApi(apiConfiguration),
-	songPublishingApi: new SongPublishingApi(apiConfiguration),
-	songValidationApi: new SongValidationApi(apiConfiguration),
-	songNotesApi: new SongNotesApi(apiConfiguration),
-	songFavouritesApi: new SongFavouritesApi(apiConfiguration),
-	authApi: new AuthApi(apiConfiguration),
-	permissionApi: new PermissionsApi(apiConfiguration),
-	analyticsApi: new AnalyticsApi(apiConfiguration),
-	mailApi: new MailApi(apiConfiguration),
-	imagesApi: new ImagesApi(apiConfiguration),
-	bridgeApi: new BridgeApi(apiConfiguration),
-	parserApi: new ParserApi(apiConfiguration),
-	packEmbeddingApi: new PackEmbeddingApi(apiConfiguration),
-	songManagementApi: new SongManagementApi(apiConfiguration),
-	songUserManagementApi: new SongUserManagementApi(apiConfiguration),
-	messengerApi: new MessengerApi(apiConfiguration),
+export const getApiClasses = (apiConfiguration: Configuration) => {
+        const playlistGettingApi = new PlaylistGettingApi(apiConfiguration)
+        const playlistEditingApi = new PlaylistEditingApi(apiConfiguration)
+        const songGettingApi = new SongGettingApi(apiConfiguration)
+        const songSearchingApi = new SongSearchingApi(apiConfiguration)
+        const songAddingApi = new SongAddingApi(apiConfiguration)
+        const songEditingApi = new SongEditingApi(apiConfiguration)
+        const songDeletingApi = new SongDeletingApi(apiConfiguration)
+        const songPublishingApi = new SongPublishingApi(apiConfiguration)
+        const songValidationApi = new SongValidationApi(apiConfiguration)
+        const songNotesApi = new SongNotesApi(apiConfiguration)
+        const songFavouritesApi = new SongFavouritesApi(apiConfiguration)
+        const authApi = new AuthApi(apiConfiguration)
+        const permissionApi = new PermissionsApi(apiConfiguration)
+        const analyticsApi = new AnalyticsApi(apiConfiguration)
+        const mailApi = new MailApi(apiConfiguration)
+        const imagesApi = new ImagesApi(apiConfiguration)
+        const bridgeApi = new BridgeApi(apiConfiguration)
+        const parserApi = new ParserApi(apiConfiguration)
+        const packEmbeddingApi = new PackEmbeddingApi(apiConfiguration)
+        const songManagementApi = new SongManagementApi(apiConfiguration)
+        const songUserManagementApi = new SongUserManagementApi(apiConfiguration)
+        const messengerApi = new MessengerApi(apiConfiguration)
 
-	// submodules
-	teamAddingApi: new TeamAddingApi(apiConfiguration),
-	teamGettingApi: new TeamGettingApi(apiConfiguration),
-	teamEditingApi: new TeamEditingApi(apiConfiguration),
-	teamJoiningApi: new TeamJoiningApi(apiConfiguration),
-	teamMembersApi: new TeamMembersApi(apiConfiguration),
-	teamEventsApi: new TeamEventsApi(apiConfiguration),
-	teamPlaylistsApi: new TeamPlaylistsApi(apiConfiguration),
-	teamSongNotesApi: new TeamSongNotesApi(apiConfiguration),
-	teamStatisticsApi: new TeamStatisticsApi(apiConfiguration),
-})
+        // submodules
+        const teamAddingApi = new TeamAddingApi(apiConfiguration)
+        const teamGettingApi = new TeamGettingApi(apiConfiguration)
+        const teamEditingApi = new TeamEditingApi(apiConfiguration)
+        const teamJoiningApi = new TeamJoiningApi(apiConfiguration)
+        const teamMembersApi = new TeamMembersApi(apiConfiguration)
+        const teamEventsApi = new TeamEventsApi(apiConfiguration)
+        const teamPlaylistsApi = new TeamPlaylistsApi(apiConfiguration)
+        const teamSongNotesApi = new TeamSongNotesApi(apiConfiguration)
+        const teamStatisticsApi = new TeamStatisticsApi(apiConfiguration)
+
+        return {
+                playlistGettingApi: wrapApi(playlistGettingApi, {
+                        playlistGettingControllerGetPlaylistDataByGuid:
+                                mapPlaylistDataOutDtoToPlaylistDto,
+                }),
+                playlistEditingApi: wrapApi(playlistEditingApi, {
+                        playlistEditingControllerAddVariantToPlaylist:
+                                mapPlaylistItemOutDtoApiToPlaylistItemDto,
+                        playlistEditingControllerCreatePlaylist: (r: any) =>
+                                r.guid as PlaylistGuid,
+                }),
+                songGettingApi: wrapApi(songGettingApi),
+                songSearchingApi: wrapApi(songSearchingApi, {
+                        songSearchingControllerSearch: (d: any) =>
+                                d.map((i: any) => mapSearchSongPacksApiToDto(i)),
+                }),
+                songAddingApi: wrapApi(songAddingApi),
+                songEditingApi: wrapApi(songEditingApi),
+                songDeletingApi: wrapApi(songDeletingApi),
+                songPublishingApi: wrapApi(songPublishingApi),
+                songValidationApi: wrapApi(songValidationApi),
+                songNotesApi: wrapApi(songNotesApi),
+                songFavouritesApi: wrapApi(songFavouritesApi),
+                authApi: wrapApi(authApi),
+                permissionApi: wrapApi(permissionApi),
+                analyticsApi: wrapApi(analyticsApi),
+                mailApi: wrapApi(mailApi),
+                imagesApi: wrapApi(imagesApi),
+                bridgeApi: wrapApi(bridgeApi),
+                parserApi: wrapApi(parserApi),
+                packEmbeddingApi: wrapApi(packEmbeddingApi, {
+                        packEmbeddingSearchControllerSearch: (arr: any[]) =>
+                                arr.map((s: any) => ({
+                                        found: [mapBasicVariantPackApiToDto(s)],
+                                })),
+                }),
+                songManagementApi: wrapApi(songManagementApi),
+                songUserManagementApi: wrapApi(songUserManagementApi),
+                messengerApi: wrapApi(messengerApi),
+
+                // submodules
+                teamAddingApi: wrapApi(teamAddingApi),
+                teamGettingApi: wrapApi(teamGettingApi),
+                teamEditingApi: wrapApi(teamEditingApi),
+                teamJoiningApi: wrapApi(teamJoiningApi),
+                teamMembersApi: wrapApi(teamMembersApi),
+                teamEventsApi: wrapApi(teamEventsApi),
+                teamPlaylistsApi: wrapApi(teamPlaylistsApi),
+                teamSongNotesApi: wrapApi(teamSongNotesApi),
+                teamStatisticsApi: wrapApi(teamStatisticsApi),
+        }
+}
+
+export const getServerApiClasses = (apiConfiguration: Configuration) => {
+        const classes = getApiClasses(apiConfiguration)
+        const wrapped: any = {}
+        for (const [key, api] of Object.entries(classes)) {
+                wrapped[key] = wrapServerApi(api as any)
+        }
+        return wrapped as ApiClasses
+}

--- a/src/hooks/api/useServerApi.tsx
+++ b/src/hooks/api/useServerApi.tsx
@@ -1,7 +1,7 @@
 'use server'
 
 import { Configuration } from '@/api/generated'
-import { getApiClasses } from '@/hooks/api/tech'
+import { getServerApiClasses } from '@/hooks/api/tech'
 import { UserDto } from '@/interfaces/user'
 import { getServerUser } from '@/tech/auth/getServerUser'
 
@@ -16,7 +16,7 @@ export async function useServerApi() {
 	}
 
 	// Return APIs
-	const apis = getApiClasses(apiConfiguration)
+        const apis = getServerApiClasses(apiConfiguration)
 
 	return apis
 }

--- a/src/hooks/auth/useAuth.tsx
+++ b/src/hooks/auth/useAuth.tsx
@@ -22,7 +22,6 @@ import {
 import { SignUpRequestDTO, loginResultDTOToUser } from '../../api/dtos/dtosAuth'
 import { AuthApi, Configuration, LoginInputData } from '../../api/generated'
 import { ROLES, UserDto } from '../../interfaces/user'
-import { handleApiCall } from '../../tech/handleApiCall'
 
 export const authContext = createContext<ReturnType<typeof useProvideAuth>>({
 	login: async () => {},
@@ -219,34 +218,28 @@ export function useProvideAuth() {
 		return _getCookie() !== undefined
 	}
 
-	const changePassword = useCallback(
-		async (oldPassword: string, newPassword: string) => {
-			if (!user) return
-			await handleApiCall(
-				authApi.authControllerChangePassword({ newPassword, oldPassword })
-			)
-		},
-		[authApi, user]
-	)
+        const changePassword = useCallback(
+                async (oldPassword: string, newPassword: string) => {
+                        if (!user) return
+                        await authApi.authControllerChangePassword({ newPassword, oldPassword })
+                },
+                [authApi, user]
+        )
 
-	const resetPassword = useCallback(
-		async (resetToken: string, newPassword: string) => {
-			await handleApiCall(
-				authApi.authControllerResetPassword({ resetToken, newPassword })
-			)
-		},
-		[authApi]
-	)
+        const resetPassword = useCallback(
+                async (resetToken: string, newPassword: string) => {
+                        await authApi.authControllerResetPassword({ resetToken, newPassword })
+                },
+                [authApi]
+        )
 
-	const sendResetLink = useCallback(
-		async (email: string) => {
-			const result = await handleApiCall(
-				authApi.authControllerSendResetToken(email)
-			)
-			return result
-		},
-		[authApi]
-	)
+        const sendResetLink = useCallback(
+                async (email: string) => {
+                        const result = await authApi.authControllerSendResetToken(email)
+                        return result
+                },
+                [authApi]
+        )
 
 	const reloadInfo = useCallback(
 		(partialUser: Partial<UserDto>) => {

--- a/src/hooks/common-data/fetchCommonDataServer.ts
+++ b/src/hooks/common-data/fetchCommonDataServer.ts
@@ -4,7 +4,6 @@ import {
 	AllCommonData,
 	TranslationLike,
 } from '@/hooks/common-data/common-data.types'
-import { handleServerApiCall } from '@/tech/fetch/handleServerApiCall'
 
 // This all is sent on every first request... so optimize it!
 
@@ -13,17 +12,13 @@ export const fetchAllCommonDataServer = async (): Promise<AllCommonData> => {
 
 	try {
 		/** Get translation likes of user */
-		const tLikes = await handleServerApiCall(
-			api.songUserManagementApi.songTranslationLikeControllerGetUserLikes()
-		)
+                const tLikes = await api.songUserManagementApi.songTranslationLikeControllerGetUserLikes()
 		const tlFormatted: TranslationLike[] = tLikes.likes.map((tl) => ({
 			packGuid: tl.packGuid as PackGuid,
 		}))
 
 		/** Get teams of user */
-		const teams = await handleServerApiCall(
-			api.teamMembersApi.teamMemberControllerGetTeamsOfUser()
-		)
+                const teams = await api.teamMembersApi.teamMemberControllerGetTeamsOfUser()
 
 		/** Get playlist of user */
 		// const playlists = await handleServerApiCall(
@@ -31,9 +26,7 @@ export const fetchAllCommonDataServer = async (): Promise<AllCommonData> => {
 		// )
 
 		/** Get all subdomains */
-		const subdomains = await handleServerApiCall(
-			api.teamGettingApi.teamGettingControllerGetAllSubdomains()
-		)
+                const subdomains = await api.teamGettingApi.teamGettingControllerGetAllSubdomains()
 
 		/** Get user permissions */
 		// const p = await handleServerApiCall(

--- a/src/hooks/dragsong/tech.ts
+++ b/src/hooks/dragsong/tech.ts
@@ -1,6 +1,5 @@
 import { SongVariantDto, VariantPackAlias, VariantPackGuid } from '@/api/dtos'
 import { SongGettingApi } from '@/api/generated'
-import { handleApiCall } from '../../tech/handleApiCall'
 
 export type DragSongDto = {
 	packGuid: VariantPackGuid
@@ -39,16 +38,14 @@ const getSongDataFromExternalUrl = async (
 ): Promise<DragSongDto | null> => {
 	console.log(url)
 
-	try {
-		const data = await handleApiCall(
-			songGettingApi.songGettingControllerGetPublicSongBySource(url)
-		)
-		return {
-			packGuid: data.packGuid as VariantPackGuid,
-			alias: data.alias as VariantPackAlias,
-			title: data.title,
-			draggedFromExternalSource: true,
-		}
+        try {
+                const data = await songGettingApi.songGettingControllerGetPublicSongBySource(url)
+                return {
+                        packGuid: data.packGuid as VariantPackGuid,
+                        alias: data.alias as VariantPackAlias,
+                        title: data.title,
+                        draggedFromExternalSource: true,
+                }
 	} catch (e) {}
 	return null
 }

--- a/src/hooks/favourites/useFavourites.tsx
+++ b/src/hooks/favourites/useFavourites.tsx
@@ -3,7 +3,6 @@ import { GetFavouritesOutDto } from '@/api/generated'
 import { useApi } from '@/hooks/api/useApi'
 import useAuth from '@/hooks/auth/useAuth'
 import { useApiState } from '@/tech/ApiState'
-import { handleApiCall } from '@/tech/handleApiCall'
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 
 type Rt = ReturnType<typeof useProvideFavourites>
@@ -38,12 +37,12 @@ const useProvideFavourites = () => {
 
 	const { fetchApiState, apiState } = useApiState<GetFavouritesOutDto>()
 
-	const reload = async () => {
-		if (!user) return
-		const data = await fetchApiState(() =>
-			handleApiCall(songFavouritesApi.songFavouritesControllerGetFavourites())
-		)
-		if (data) setFavourites(data)
+        const reload = async () => {
+                if (!user) return
+                const data = await fetchApiState(() =>
+                        songFavouritesApi.songFavouritesControllerGetFavourites()
+                )
+                if (data) setFavourites(data)
 	}
 
 	const first = useRef(true)
@@ -55,20 +54,16 @@ const useProvideFavourites = () => {
 		reload()
 	}, [user])
 
-	const add = async (packGuid: VariantPackGuid) => {
-		const result = await handleApiCall(
-			songFavouritesApi.songFavouritesControllerAddFavourite({ packGuid })
-		)
-		reload()
-		return result
-	}
-	const remove = async (packGuid: VariantPackGuid) => {
-		const result = await handleApiCall(
-			songFavouritesApi.songFavouritesControllerRemoveFavourite({ packGuid })
-		)
-		reload()
-		return result
-	}
+        const add = async (packGuid: VariantPackGuid) => {
+                const result = await songFavouritesApi.songFavouritesControllerAddFavourite({ packGuid })
+                reload()
+                return result
+        }
+        const remove = async (packGuid: VariantPackGuid) => {
+                const result = await songFavouritesApi.songFavouritesControllerRemoveFavourite({ packGuid })
+                reload()
+                return result
+        }
 
 	return {
 		items: favourites?.items || null,

--- a/src/hooks/permissions/usePermissions.tsx
+++ b/src/hooks/permissions/usePermissions.tsx
@@ -4,7 +4,6 @@ import {
 	permissionPayloadToApi,
 } from '../../api/dtos/permission'
 import { useApiState } from '../../tech/ApiState'
-import { handleApiCall } from '../../tech/handleApiCall'
 import { useApi } from '../api/useApi'
 import useAuth from '../auth/useAuth'
 import {
@@ -70,17 +69,15 @@ function useProvidePermissions<
 		useApiState<PermissionDataType<Merge<A>, PermissionType<Merge<A>>>[]>()
 
 	const reload = async () => {
-		fetchApiState(async () => {
-			if (!isLoggedIn()) return []
-			const data = await handleApiCall(
-				permissionApi.permissionControllerGetUserPermissions(userGuid)
-			)
-			return data.map((p) => {
-				return {
-					type: p.type as PermissionType<Merge<A>>,
-					payload: apiToPermissionPayload(p.payload),
-					guid: p.guid,
-				}
+                fetchApiState(async () => {
+                        if (!isLoggedIn()) return []
+                        const data = await permissionApi.permissionControllerGetUserPermissions(userGuid)
+                        return data.map((p) => {
+                                return {
+                                        type: p.type as PermissionType<Merge<A>>,
+                                        payload: apiToPermissionPayload(p.payload),
+                                        guid: p.guid,
+                                }
 			})
 		})
 			.then((r) => {
@@ -98,14 +95,12 @@ function useProvidePermissions<
 		payload: PermissionPayloadType<Merge<A>, T>
 	) => {
 		if (!isLoggedIn()) return []
-		const data = await handleApiCall(
-			permissionApi.permissionControllerGetAllUsersWithPermission(
-				type,
-				permissionPayloadToApi(payload)
-			)
-		)
-		return data
-	}
+                const data = await permissionApi.permissionControllerGetAllUsersWithPermission(
+                        type,
+                        permissionPayloadToApi(payload)
+                )
+                return data
+        }
 
 	return {
 		reload,

--- a/src/hooks/playlist/usePlaylistsGeneral.ts
+++ b/src/hooks/playlist/usePlaylistsGeneral.ts
@@ -4,10 +4,6 @@ import { EditPlaylistItemData } from '@/hooks/playlist/usePlaylistsGeneral.types
 import { Chord } from '@pepavlin/sheet-api'
 import { useCallback } from 'react'
 import {
-	mapPlaylistDataOutDtoToPlaylistDto,
-	mapPlaylistItemOutDtoApiToPlaylistItemDto,
-} from '../../api/dtos/playlist/playlist.map'
-import {
 	GetSearchInPlaylistResult,
 	ReorderPlaylistInDto,
 } from '../../api/generated'
@@ -16,7 +12,6 @@ import Playlist, {
 	PlaylistItemDto,
 	PlaylistItemGuid,
 } from '../../interfaces/playlist/playlist.types'
-import { hac, handleApiCall } from '../../tech/handleApiCall'
 
 export const PLAYLIST_UPDATE_EVENT_NAME = 'playlist-update'
 
@@ -26,17 +21,15 @@ export const getPlaylistUpdateEventName = (guid: PlaylistGuid) =>
 export default function usePlaylistsGeneral() {
 	const { playlistEditingApi, playlistGettingApi } = useApi()
 
-	const addVariantToPlaylist = async (
-		packGuid: VariantPackGuid,
-		playlist: PlaylistGuid
-	) => {
-		return await handleApiCall(
-			playlistEditingApi.playlistEditingControllerAddVariantToPlaylist({
-				playlist,
-				packGuid,
-			})
-		)
-	}
+        const addVariantToPlaylist = async (
+                packGuid: VariantPackGuid,
+                playlist: PlaylistGuid
+        ) => {
+                return await playlistEditingApi.playlistEditingControllerAddVariantToPlaylist({
+                        playlist,
+                        packGuid,
+                })
+        }
 
 	const addPacksToPlaylist = async (
 		packGuids: VariantPackGuid[],
@@ -45,142 +38,108 @@ export default function usePlaylistsGeneral() {
 		const newItems: PlaylistItemDto[] = []
 		for (const packGuid of packGuids) {
 			try {
-				const data = await addVariantToPlaylist(packGuid, playlist).then(
-					async (r) => {
-						if (!r) return false
-						const item = mapPlaylistItemOutDtoApiToPlaylistItemDto(r)
-						return item
-					}
-				)
-				if (data) newItems.push(data)
+                                const data = await addVariantToPlaylist(packGuid, playlist)
+                                if (data) newItems.push(data)
 			} catch (e) {}
 		}
 
 		return newItems
 	}
 
-	const removeVariantFromPlaylist = async (
-		packGuid: VariantPackGuid,
-		playlist: PlaylistGuid
-	) => {
-		return await handleApiCall(
-			playlistEditingApi.playlistEditingControllerRemoveVariantFromPlaylistDelete(
-				packGuid,
-				playlist
-			)
-		)
-	}
+        const removeVariantFromPlaylist = async (
+                packGuid: VariantPackGuid,
+                playlist: PlaylistGuid
+        ) => {
+                return await playlistEditingApi.playlistEditingControllerRemoveVariantFromPlaylistDelete(
+                        packGuid,
+                        playlist
+                )
+        }
 
-	const isVariantInPlaylist = async (
-		packGuid: VariantPackGuid,
-		playlist: PlaylistGuid
-	): Promise<boolean> => {
-		const result = await handleApiCall(
-			playlistGettingApi.playlistGettingControllerIsVariantInPlaylist(
-				packGuid,
-				playlist
-			)
-		)
+        const isVariantInPlaylist = async (
+                packGuid: VariantPackGuid,
+                playlist: PlaylistGuid
+        ): Promise<boolean> => {
+                return await playlistGettingApi.playlistGettingControllerIsVariantInPlaylist(
+                        packGuid,
+                        playlist
+                )
+        }
 
-		return result
-	}
+        const getPlaylistsOfUser = async () => {
+                return await playlistGettingApi.playlistGettingControllerGetPlaylistsOfUser()
+        }
 
-	const getPlaylistsOfUser = async () => {
-		return await handleApiCall(
-			playlistGettingApi.playlistGettingControllerGetPlaylistsOfUser()
-		)
-	}
+        const createPlaylist = async (): Promise<PlaylistGuid> => {
+                return await playlistEditingApi.playlistEditingControllerCreatePlaylist()
+        }
 
-	const createPlaylist = async (): Promise<PlaylistGuid> => {
-		const createdApi = await handleApiCall(
-			playlistEditingApi.playlistEditingControllerCreatePlaylist()
-		)
-		return createdApi.guid as PlaylistGuid
-	}
+        const deletePlaylist = async (guid: PlaylistGuid) => {
+                const r = await playlistEditingApi.playlistEditingControllerDeletePlaylist(guid)
+                updatePlaylistTick(guid)
+                return r
+        }
 
-	const deletePlaylist = async (guid: PlaylistGuid) => {
-		const r = await handleApiCall(
-			playlistEditingApi.playlistEditingControllerDeletePlaylist(guid)
-		)
-		updatePlaylistTick(guid)
-		return r
-	}
-
-	const getPlaylistByGuid = async (guid: PlaylistGuid): Promise<Playlist> => {
-		const result = await handleApiCall(
-			playlistGettingApi.playlistGettingControllerGetPlaylistDataByGuid(guid)
-		)
-		return mapPlaylistDataOutDtoToPlaylistDto(result)
-	}
+        const getPlaylistByGuid = async (guid: PlaylistGuid): Promise<Playlist> => {
+                return await playlistGettingApi.playlistGettingControllerGetPlaylistDataByGuid(guid)
+        }
 
 	const searchInPlaylistByGuid = useCallback(
 		async (
 			playlistGuid: PlaylistGuid,
 			searchString: string
 		): Promise<GetSearchInPlaylistResult> => {
-			return await handleApiCall(
-				playlistGettingApi.playlistGettingControllerSearchInPlaylist(
-					searchString,
-					playlistGuid
-				)
-			)
+                        return await playlistGettingApi.playlistGettingControllerSearchInPlaylist(
+                                searchString,
+                                playlistGuid
+                        )
 		},
 		[playlistGettingApi]
 	)
 
-	const renamePlaylist = async (guid: PlaylistGuid, title: string) => {
-		return await handleApiCall(
-			playlistEditingApi.playlistEditingControllerRenamePlaylist({
-				guid,
-				title,
-			})
-		)
-	}
+        const renamePlaylist = async (guid: PlaylistGuid, title: string) => {
+                return await playlistEditingApi.playlistEditingControllerRenamePlaylist({
+                        guid,
+                        title,
+                })
+        }
 
-	const reorderPlaylist = async (
-		playlistGuid: PlaylistGuid,
-		items: ReorderPlaylistInDto['items']
-	) => {
-		return await handleApiCall(
-			playlistEditingApi.playlistEditingControllerReorderPlaylist({
-				guid: playlistGuid,
-				items,
-			})
-		)
-	}
+        const reorderPlaylist = async (
+                playlistGuid: PlaylistGuid,
+                items: ReorderPlaylistInDto['items']
+        ) => {
+                return await playlistEditingApi.playlistEditingControllerReorderPlaylist({
+                        guid: playlistGuid,
+                        items,
+                })
+        }
 
-	const setKeyChordOfItem = async (guid: PlaylistItemGuid, keyChord: Chord) => {
-		return await handleApiCall(
-			playlistEditingApi.playlistEditingControllerTransposePlaylistItem({
-				guid,
-				key: keyChord.data.rootNote.toString(),
-			})
-		)
-	}
+        const setKeyChordOfItem = async (guid: PlaylistItemGuid, keyChord: Chord) => {
+                return await playlistEditingApi.playlistEditingControllerTransposePlaylistItem({
+                        guid,
+                        key: keyChord.data.rootNote.toString(),
+                })
+        }
 
-	const editPlaylistItem = async (
-		guid: PlaylistItemGuid,
-		data: EditPlaylistItemData
-	) => {
-		return await hac(
-			playlistEditingApi.playlistEditingControllerEditItem({
-				itemGuid: guid,
-				title: data.title,
-				sheetData: data.sheetData,
-			})
-		)
-	}
+        const editPlaylistItem = async (
+                guid: PlaylistItemGuid,
+                data: EditPlaylistItemData
+        ) => {
+                return await playlistEditingApi.playlistEditingControllerEditItem({
+                        itemGuid: guid,
+                        title: data.title,
+                        sheetData: data.sheetData,
+                })
+        }
 
 	const requireItemEdit = useCallback(
 		async (guid: PlaylistItemGuid) => {
-			return await handleApiCall(
-				playlistEditingApi.playlistEditingControllerRequireItemEdit({
-					itemGuid: guid,
-				})
-			)
-		},
-		[playlistEditingApi]
-	)
+                        return await playlistEditingApi.playlistEditingControllerRequireItemEdit({
+                                itemGuid: guid,
+                        })
+                },
+                [playlistEditingApi]
+        )
 
 	const updatePlaylistTick = async (guid: PlaylistGuid) => {
 		window.dispatchEvent(

--- a/src/hooks/song/useSongSearch.tsx
+++ b/src/hooks/song/useSongSearch.tsx
@@ -1,11 +1,6 @@
-import {
-	mapSearchSongPacksApiToDto,
-	SearchSongDto,
-} from '@/api/dtos/song/song.search.dto'
+import { SearchSongDto } from '@/api/dtos/song/song.search.dto'
 import { SearchKey } from '@/types/song/search.types'
 import { useCallback } from 'react'
-import { mapBasicVariantPackApiToDto } from '../../api/dtos'
-import { handleApiCall } from '../../tech/handleApiCall'
 import { useApi } from '../api/useApi'
 import useAuth from '../auth/useAuth'
 
@@ -21,7 +16,7 @@ type GetSongFunction = (
 ) => Promise<SearchSongDto[]>
 
 export default function useSongSearch() {
-	const { songGettingApi, packEmbeddingApi, songSearchingApi } = useApi()
+        const { songGettingApi, packEmbeddingApi, songSearchingApi } = useApi()
 	const { user } = useAuth()
 
 	const getSongs: GetSongFunction = useCallback(
@@ -31,33 +26,25 @@ export default function useSongSearch() {
 		): Promise<SearchSongDto[]> => {
 			try {
 				// Handle smart search
-				if (additionalParams?.useSmartSearch) {
-					return (
-						await handleApiCall(
-							packEmbeddingApi.packEmbeddingSearchControllerSearch(
-								searchKey,
-								additionalParams?.page || 0,
-								{
-									signal: additionalParams.signal,
-								}
-							)
-						)
-					).map((s) => ({
-						found: [mapBasicVariantPackApiToDto(s)],
-					}))
-				}
+                                if (additionalParams?.useSmartSearch) {
+                                        return packEmbeddingApi.packEmbeddingSearchControllerSearch(
+                                                searchKey,
+                                                additionalParams?.page || 0,
+                                                {
+                                                        signal: additionalParams.signal,
+                                                }
+                                        )
+                                }
 
-				const result = await handleApiCall(
-					songSearchingApi.songSearchingControllerSearch(
-						searchKey,
-						additionalParams?.page || 0,
-						{
-							signal: additionalParams?.signal,
-						}
-					)
-				)
+                                const result = await songSearchingApi.songSearchingControllerSearch(
+                                        searchKey,
+                                        additionalParams?.page || 0,
+                                        {
+                                                signal: additionalParams?.signal,
+                                        }
+                                )
 
-				return result.map((d) => mapSearchSongPacksApiToDto(d))
+                                return result
 			} catch (e) {
 				console.log(e)
 			}


### PR DESCRIPTION
## Summary
- add a generic `wrapApi` helper to automatically call `handleApiCall`
- generate wrapped API clients in `getApiClasses`
- expose `getServerApiClasses` for server side calls
- update hooks to use wrapped APIs directly
- remove explicit `handleApiCall`/`handleServerApiCall` usage
- remove unused mapping import

## Testing
- `npm run test-jest` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e940e22d4832eb37774989f4198a7