### PR TITLE
Fix redirect for team playlists when user is not logged in

### DIFF
--- a/src/app/(layout)/playlist/[guid]/layout.tsx
+++ b/src/app/(layout)/playlist/[guid]/layout.tsx
@@ -4,6 +4,7 @@ import { InnerPlaylistProvider } from '@/app/(layout)/playlist/[guid]/hooks/useI
 import { useServerPathname } from '@/hooks/pathname/useServerPathname'
 import { PlaylistGuid } from '@/interfaces/playlist/playlist.types'
 import { smartRedirect } from '@/routes/routes.tech.server'
+import { getServerUser } from '@/tech/auth/getServerUser'
 import { generateSmartMetadata } from '@/tech/metadata/metadata'
 import { LayoutProps, MetadataProps } from '../../../../common/types'
 
@@ -42,16 +43,17 @@ export default async function Layout(props: LayoutProps<'playlist'>) {
 		// console.error(e)
 	}
 
-	const pathname = await useServerPathname()
-	const afterPlaylist = pathname.split('playlist')[1]
-	const isSomethingAfter = afterPlaylist.split('/').length > 2
+       const pathname = await useServerPathname()
+       const afterPlaylist = pathname.split('playlist')[1]
+       const isSomethingAfter = afterPlaylist.split('/').length > 2
+       const user = getServerUser()
 
-	if (playlist.teamAlias && !isSomethingAfter) {
-		smartRedirect('teamPlaylist', {
-			alias: playlist.teamAlias,
-			guid: props.params.guid,
-		})
-	}
+       if (playlist.teamAlias && !isSomethingAfter && user) {
+               smartRedirect('teamPlaylist', {
+                       alias: playlist.teamAlias,
+                       guid: props.params.guid,
+               })
+       }
 	return (
 		<InnerPlaylistProvider guid={props.params.guid as PlaylistGuid}>
 			{props.children}


### PR DESCRIPTION
## Summary
- avoid redirecting to team playlist when viewer isn't logged in

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68849ddf03c4832e812b58e823a7a7d2