### PR TITLE
Add hallelujahhub deployment, better workflow structure

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+Workflows exists to automate common tasks such as testing, building, and deploying the project.
+
+Testing:
+
+1. For every pull request or change, should be tested by basic **jest tests**
+2. After every pull request to 'dev' branch, should be run **e2e tests** on deployed version
+
+Deployment:
+
+1. On every push to 'dev' branch, should be deployed
+2. On every push to 'main' branch, should be deployed to production
+   - main (shared db)
+     - chvalotce.cz
+     - worship.cz
+   - non-czech (different db)
+     hallelujahhub.com

--- a/.github/workflows/production-chvalotce-deployment.yml
+++ b/.github/workflows/production-chvalotce-deployment.yml
@@ -1,22 +1,20 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
-name: Deploy to chvalotce.cz (Production)
+name: Chvalotce Production Deployment
 
 env:
-  SERVER_USERNAME: chvalotce-docker
-  SERVER_URL: chvalotce.cz
+  CHVALOTCE_SERVER_USERNAME: chvalotce-docker
+  CHVALOTCE_SERVER_URL: chvalotce.cz
   DOCKER_IMAGE_NAME: worshiptool
 
 on:
   workflow_dispatch:
-  #   release:
-  #     types: [published]
   push:
     branches: [master]
 
 jobs:
-  release:
+  upload-to-docker-chvalotce:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,14 +35,25 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build
-        run: docker build -t ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:latest .
+        run: docker build -t ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:latest -t ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:chvalotce-prod .
 
       - name: Log Images
         run: docker images
 
       - name: Push
-        run: docker push ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:latest
+        run: |
+          docker push ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:latest
+          docker push ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:chvalotce-prod
 
+  deploy-to-chvalotce:
+    needs: upload-to-docker-chvalotce
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
       - name: Redeploy application
         run: |
-          ssh -o ServerAliveInterval=1000 "${SERVER_USERNAME}@${SERVER_URL}" "cd /home/chvalotce.cz-docker/project-deploy/worshiptool/frontend && bash ./redeploy.sh && cd /home/chvalotce.cz-docker/scripts && bash ./send-message.sh 'Nová verze frontendu byla právě nasazena.'"
+          ssh -o ServerAliveInterval=1000 "${SERVER_USERNAME}@${SERVER_URL}" "cd /home/chvalotce.cz-docker/project-deploy/worshiptool/frontend && bash ./redeploy.sh "

--- a/.github/workflows/production-hallelujah-deployment.yml
+++ b/.github/workflows/production-hallelujah-deployment.yml
@@ -1,0 +1,58 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: HallelujahHub Production Deployment
+
+env:
+  HALLELUJAHHUB_SERVER_USERNAME: root
+  HALLELUJAHHUB_SERVER_URL: 37.27.38.229
+  DOCKER_IMAGE_NAME: worshiptool
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+jobs:
+  upload-to-docker-hallelujahhub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.HALLELUJAHHUB_SSH_KEY }}
+          known_hosts: ${{ secrets.HALLELUJAHHUB_SSH_KNOWN_HOSTS }}
+
+      - name: Copy .env from remote server
+        run: scp -o StrictHostKeyChecking=no "${{ env.HALLELUJAHHUB_SERVER_USERNAME }}@${{ env.HALLELUJAHHUB_SERVER_URL }}:~/Workspace/worshiptool/hallelujahhub/frontend/.env" ./.env
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build
+        run: docker build -t ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:hallelujahhub-prod .
+
+      - name: Log Images
+        run: docker images
+
+      - name: Push
+        run: docker push ${{secrets.DOCKERHUB_USERNAME}}/${{env.DOCKER_IMAGE_NAME}}:hallelujahhub-prod
+
+  deploy-to-hallelujahhub:
+    needs: upload-to-docker-hallelujahhub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.HALLELUJAHHUB_SSH_KEY }}
+          known_hosts: ${{ secrets.HALLELUJAHHUB_SSH_KNOWN_HOSTS }}
+
+      - name: Redeploy application
+        run: |
+          ssh -o ServerAliveInterval=1000 "${{env.HALLELUJAHHUB_SERVER_USERNAME}}@${{env.HALLELUJAHHUB_SERVER_URL}}" "cd Workspace/worshiptool/hallelujahhub && bash ./redeploy.sh ./frontend"

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -13,7 +13,7 @@ export default function Error({ error, reset }: ErrorPageProps) {
 	}, [error])
 
 	useEffect(() => {
-		console.error(error)
+		console.error('Error page error:', error)
 		//TODO: send report to admin
 	}, [error])
 


### PR DESCRIPTION
chore: remove outdated node.js workflow and add production deployment workflow

feat: add production deployment workflow for Docker images

chore: update workflow name to clarify purpose for Hallelujahhub deployment

fix: correct path for copying .env file from remote server

fix: correct path for copying .env file from remote server

fix: correct path for copying .env file from Hallelujahhub remote server

feat: add production deployment workflows for Chvalotce and HallelujahHub

fix: update Docker build and push commands to include chvalotce-prod tag

feat: add production deployment workflow for HallelujahHub

chore: improve error logging on error page

chore: remove unused environment variables for HallelujahHub

fix: correct paths for .env file and redeployment script in production workflow