### PR TITLE
Chci aby v tom dialogu Implement Idea v tabu Recent ideas... aby u jednotlivych tasku hotovych byli i odkazy na jejich p

### DIFF
--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -229,6 +229,27 @@ describe('ImplementIdeaDialog', () => {
 			expect(hrefs).not.toContain('https://preview.example.com/pr-55')
 		})
 
+		it('does not show preview link for non-completed tasks even when previewUrl is available', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			process.env.NEXT_PUBLIC_PREVIEW_BASE_URL = 'https://preview.example.com'
+			const runningTaskWithPr = {
+				taskId: '5',
+				status: 'running',
+				prompt: 'Work in progress',
+				pullRequests: [{ repo: 'my-repo', url: 'https://github.com/org/repo/pull/99' }],
+			}
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [runningTaskWithPr] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
+			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
+		})
+
 		it('does not show preview link when NEXT_PUBLIC_PREVIEW_BASE_URL is not set', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			;(global.fetch as jest.Mock).mockResolvedValue({

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -350,7 +350,7 @@ export default function ImplementIdeaDialog({
 
 									{/* Action buttons */}
 									<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0, alignItems: 'flex-end' }}>
-										{previewUrl && (
+										{task.status === 'completed' && previewUrl && (
 											<a
 												href={previewUrl}
 												target="_blank"


### PR DESCRIPTION
## Summary

V dialogu `ImplementIdeaDialog.tsx` byla změněna podmínka pro zobrazení tlačítka **Preview** – nyní se zobrazuje pouze u úkolů se stavem `completed` (přidána podmínka `task.status === 'completed'`). Zároveň byl přidán nový test, který ověřuje, že pro neukončené úkoly (např. `running`) se tlačítko Preview nezobrazuje, i když by URL bylo dostupné. Build i testy prošly bez chyb.

## Commits

- feat: show preview URL links only for completed tasks in Implement Idea dialog