### PR TITLE
Udelej, aby dialog implement idea, byl ve spravnem jazyce... Ted na ceske verzi stranky mi to ukazuje v anglickem jazyce

### DIFF
--- a/content/chvalotce.d.json.ts
+++ b/content/chvalotce.d.json.ts
@@ -960,6 +960,28 @@ declare const messages: {
 		"smartSearchNote": "💡 Funkce je stále ve vývoji a ladí se.",
 		"smartSearchStep1": "Přepněte na chytré vyhledávání",
 		"smartSearchStep2": "Zadejte téma nebo náladu, kterou hledáte"
+	},
+	"implementIdea": {
+		"title": "Implementovat nápad",
+		"submitIdeaTab": "Odeslat nápad",
+		"recentIdeasTab": "Poslední nápady",
+		"recentIdeasTabActive": "Poslední nápady ({count} aktivní)",
+		"heading": "Co chcete vytvořit?",
+		"subtitle": "Popište svůj nápad a bude automaticky implementován.",
+		"placeholder": "Popište svůj nápad...",
+		"submitButton": "Odeslat nápad",
+		"loading": "Načítání...",
+		"noIdeas": "Zatím žádné nápady.",
+		"ideaSubmitted": "Nápad odeslán!",
+		"submitFailed": "Nepodařilo se odeslat nápad.",
+		"status": {
+			"queued": "Ve frontě",
+			"running": "Probíhá",
+			"retrying": "Opakování",
+			"completed": "Dokončeno",
+			"failed": "Selhalo",
+			"interrupted": "Přerušeno"
+		}
 	}
 };
 export default messages;

--- a/content/chvalotce.json
+++ b/content/chvalotce.json
@@ -957,5 +957,27 @@
 		"smartSearchNote": "💡 Funkce je stále ve vývoji a ladí se.",
 		"smartSearchStep1": "Přepněte na chytré vyhledávání",
 		"smartSearchStep2": "Zadejte téma nebo náladu, kterou hledáte"
+	},
+	"implementIdea": {
+		"title": "Implementovat nápad",
+		"submitIdeaTab": "Odeslat nápad",
+		"recentIdeasTab": "Poslední nápady",
+		"recentIdeasTabActive": "Poslední nápady ({count} aktivní)",
+		"heading": "Co chcete vytvořit?",
+		"subtitle": "Popište svůj nápad a bude automaticky implementován.",
+		"placeholder": "Popište svůj nápad...",
+		"submitButton": "Odeslat nápad",
+		"loading": "Načítání...",
+		"noIdeas": "Zatím žádné nápady.",
+		"ideaSubmitted": "Nápad odeslán!",
+		"submitFailed": "Nepodařilo se odeslat nápad.",
+		"status": {
+			"queued": "Ve frontě",
+			"running": "Probíhá",
+			"retrying": "Opakování",
+			"completed": "Dokončeno",
+			"failed": "Selhalo",
+			"interrupted": "Přerušeno"
+		}
 	}
 }

--- a/content/chwalmy.json
+++ b/content/chwalmy.json
@@ -957,5 +957,27 @@
 		"smartSearchNote": "💡 Funkcja jest wciąż w fazie rozwoju.",
 		"smartSearchStep1": "Przełącz na inteligentne wyszukiwanie",
 		"smartSearchStep2": "Wpisz temat lub nastrój, którego szukasz"
+	},
+	"implementIdea": {
+		"title": "Implementuj pomysł",
+		"submitIdeaTab": "Wyślij pomysł",
+		"recentIdeasTab": "Ostatnie pomysły",
+		"recentIdeasTabActive": "Ostatnie pomysły ({count} aktywne)",
+		"heading": "Co chcesz zbudować?",
+		"subtitle": "Opisz swój pomysł, a zostanie automatycznie zaimplementowany.",
+		"placeholder": "Opisz swój pomysł...",
+		"submitButton": "Wyślij pomysł",
+		"loading": "Ładowanie...",
+		"noIdeas": "Nie przesłano jeszcze żadnych pomysłów.",
+		"ideaSubmitted": "Pomysł wysłany!",
+		"submitFailed": "Nie udało się wysłać pomysłu.",
+		"status": {
+			"queued": "W kolejce",
+			"running": "W toku",
+			"retrying": "Ponowna próba",
+			"completed": "Ukończono",
+			"failed": "Nieudane",
+			"interrupted": "Przerwano"
+		}
 	}
 }

--- a/content/hallelujahhub.json
+++ b/content/hallelujahhub.json
@@ -974,5 +974,27 @@
 		"smartSearchNote": "💡 This feature is still in development.",
 		"smartSearchStep1": "Switch to smart search",
 		"smartSearchStep2": "Enter the theme or mood you're looking for"
+	},
+	"implementIdea": {
+		"title": "Implement an idea",
+		"submitIdeaTab": "Submit idea",
+		"recentIdeasTab": "Recent ideas",
+		"recentIdeasTabActive": "Recent ideas ({count} active)",
+		"heading": "What would you like to build?",
+		"subtitle": "Describe your idea and it will be implemented automatically.",
+		"placeholder": "Describe your idea...",
+		"submitButton": "Submit idea",
+		"loading": "Loading...",
+		"noIdeas": "No ideas submitted yet.",
+		"ideaSubmitted": "Idea submitted!",
+		"submitFailed": "Failed to submit idea.",
+		"status": {
+			"queued": "Queued",
+			"running": "Running",
+			"retrying": "Retrying",
+			"completed": "Completed",
+			"failed": "Failed",
+			"interrupted": "Interrupted"
+		}
 	}
 }

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -3,6 +3,18 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import React from 'react'
 import ImplementIdeaDialog from './ImplementIdeaDialog'
 
+jest.mock('next-intl', () => ({
+	useTranslations: () => {
+		const t = (key: string, params?: Record<string, unknown>) => {
+			if (params && typeof params.count !== 'undefined') {
+				return `${key}:${params.count}`
+			}
+			return key
+		}
+		return t
+	},
+}))
+
 jest.mock('notistack', () => ({
 	useSnackbar: () => ({ enqueueSnackbar: jest.fn() }),
 }))
@@ -97,7 +109,8 @@ describe('ImplementIdeaDialog', () => {
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
 			await waitFor(() => {
-				expect(screen.getByText(/2 active/)).toBeInTheDocument()
+				// Mock returns 'recentIdeasTabActive:2' for t('recentIdeasTabActive', { count: 2 })
+				expect(screen.getByText(/recentIdeasTabActive:2/)).toBeInTheDocument()
 			})
 		})
 
@@ -110,7 +123,7 @@ describe('ImplementIdeaDialog', () => {
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
 			await waitFor(() => {
-				expect(screen.getByText('Recent ideas')).toBeInTheDocument()
+				expect(screen.getByText('recentIdeasTab')).toBeInTheDocument()
 			})
 		})
 	})
@@ -124,7 +137,7 @@ describe('ImplementIdeaDialog', () => {
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
-			await waitFor(() => screen.getByText(/2 active/))
+			await waitFor(() => screen.getByText(/recentIdeasTabActive/))
 
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
@@ -139,7 +152,7 @@ describe('ImplementIdeaDialog', () => {
 			})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await waitFor(() => screen.getByText(/2 active/))
+			await waitFor(() => screen.getByText(/recentIdeasTabActive/))
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const items = screen.getAllByText(/mode|bug|auth/i)
@@ -156,7 +169,7 @@ describe('ImplementIdeaDialog', () => {
 			})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await waitFor(() => screen.getByText(/1 active/))
+			await waitFor(() => screen.getByText(/recentIdeasTabActive/))
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			expect(screen.getByText('A'.repeat(120) + '…')).toBeInTheDocument()
@@ -172,7 +185,7 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			expect(screen.getByText('No ideas submitted yet.')).toBeInTheDocument()
+			expect(screen.getByText('noIdeas')).toBeInTheDocument()
 		})
 
 		it('shows preview link when NEXT_PUBLIC_PREVIEW_BASE_URL is set and task has PR', async () => {

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -8,6 +8,7 @@ import { alpha, Tab, Tabs } from '@/common/ui/mui'
 import { keyframes } from '@emotion/react'
 import { Close, Lightbulb, OpenInNew } from '@mui/icons-material'
 import { useSnackbar } from 'notistack'
+import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 
 type TaskStatus =
@@ -45,13 +46,13 @@ const bgMove = keyframes`
 const BLUE = '#0085FF'
 const BLUE_DARK = '#0060cc'
 
-const STATUS_STYLE: Record<TaskStatus, { bg: string; color: string; label: string }> = {
-	queued:      { bg: alpha('#888888', 0.1), color: '#666',    label: 'Queued'      },
-	running:     { bg: alpha(BLUE, 0.12),     color: BLUE,      label: 'Running'     },
-	retrying:    { bg: '#fff3e0',             color: '#e65100', label: 'Retrying'    },
-	completed:   { bg: '#e8f5e9',             color: '#2e7d32', label: 'Completed'   },
-	failed:      { bg: '#ffebee',             color: '#c62828', label: 'Failed'      },
-	interrupted: { bg: alpha('#888888', 0.1), color: '#666',    label: 'Interrupted' },
+const STATUS_STYLE: Record<TaskStatus, { bg: string; color: string }> = {
+	queued:      { bg: alpha('#888888', 0.1), color: '#666'    },
+	running:     { bg: alpha(BLUE, 0.12),     color: BLUE      },
+	retrying:    { bg: '#fff3e0',             color: '#e65100' },
+	completed:   { bg: '#e8f5e9',             color: '#2e7d32' },
+	failed:      { bg: '#ffebee',             color: '#c62828' },
+	interrupted: { bg: alpha('#888888', 0.1), color: '#666'    },
 }
 
 function extractPrNumber(prUrl: string): string | null {
@@ -73,6 +74,7 @@ export default function ImplementIdeaDialog({
 	open,
 	onClose,
 }: ImplementIdeaDialogProps) {
+	const t = useTranslations('implementIdea')
 	const [message, setMessage] = useState('')
 	const [loading, setLoading] = useState(false)
 	const [tasks, setTasks] = useState<Task[]>([])
@@ -128,12 +130,12 @@ export default function ImplementIdeaDialog({
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ message }),
 			})
-			enqueueSnackbar('Idea submitted!', { variant: 'success' })
+			enqueueSnackbar(t('ideaSubmitted'), { variant: 'success' })
 			setMessage('')
 			setActiveTab(1)
 			fetchTasks()
 		} catch {
-			enqueueSnackbar('Failed to submit idea.', { variant: 'error' })
+			enqueueSnackbar(t('submitFailed'), { variant: 'error' })
 		} finally {
 			setLoading(false)
 		}
@@ -188,7 +190,7 @@ export default function ImplementIdeaDialog({
 					>
 						<Lightbulb sx={{ fontSize: 15 }} />
 						<Typography variant="subtitle1" strong={600}>
-							Implement an idea
+							{t('title')}
 						</Typography>
 					</Box>
 					<IconButton small onClick={handleClose} disabled={loading}>
@@ -209,12 +211,12 @@ export default function ImplementIdeaDialog({
 						'& .Mui-selected': { color: `${BLUE} !important` },
 					}}
 				>
-					<Tab label="Submit idea" />
+					<Tab label={t('submitIdeaTab')} />
 					<Tab
 						label={
 							tasksLoaded && (inProgressCount > 0 || queuedCount > 0)
-								? `Recent ideas (${inProgressCount + queuedCount} active)`
-								: 'Recent ideas'
+								? t('recentIdeasTabActive', { count: String(inProgressCount + queuedCount) })
+								: t('recentIdeasTab')
 						}
 					/>
 				</Tabs>
@@ -225,11 +227,11 @@ export default function ImplementIdeaDialog({
 				{activeTab === 0 && (
 					<>
 						<Typography variant="h4" strong sx={{ letterSpacing: '0.02em' }}>
-							What would you like to build?
+							{t('heading')}
 						</Typography>
 						<Gap value={0.5} />
 						<Typography variant="subtitle1" strong={300} color="grey.600">
-							Describe your idea and it will be implemented automatically.
+							{t('subtitle')}
 						</Typography>
 
 						<Gap value={2} />
@@ -249,7 +251,7 @@ export default function ImplementIdeaDialog({
 							<TextField
 								value={message}
 								onChange={setMessage}
-								placeholder="Describe your idea..."
+								placeholder={t('placeholder')}
 								multiline
 								autoFocus
 								sx={{ minHeight: 80 }}
@@ -276,7 +278,7 @@ export default function ImplementIdeaDialog({
 								disabled={!message.trim() || urlMissing}
 								sx={{ borderRadius: 3, paddingX: 5, opacity: 0.9 }}
 							>
-								Submit idea
+								{t('submitButton')}
 							</Button>
 						</Box>
 
@@ -297,13 +299,13 @@ export default function ImplementIdeaDialog({
 					>
 						{!tasksLoaded && (
 							<Typography variant="normal" size="0.85rem" color="grey.500" align="center">
-								Loading...
+								{t('loading')}
 							</Typography>
 						)}
 
 						{tasksLoaded && tasks.length === 0 && (
 							<Typography variant="normal" size="0.85rem" color="grey.500" align="center">
-								No ideas submitted yet.
+								{t('noIdeas')}
 							</Typography>
 						)}
 
@@ -341,7 +343,7 @@ export default function ImplementIdeaDialog({
 											mt: 0.25,
 										}}
 									>
-										{style.label}
+										{t(`status.${task.status}`)}
 									</Box>
 
 									{/* Prompt */}


### PR DESCRIPTION
## Summary

The implementation is complete. Here's a summary of what was done:

**Added `implementIdea` translation keys to all 3 content files** — Czech (`chvalotce.json`), English (`hallelujahhub.json`), and Polish (`chwalmy.json`) — covering all UI strings: title, tabs, heading, subtitle, placeholder, button, loading state, empty state, snackbar messages, and all 6 task status labels.

**Updated `ImplementIdeaDialog.tsx`** to use `useTranslations('implementIdea')` from `next-intl`, replacing all hardcoded English strings with translation calls. The dialog now correctly displays in Czech on the Czech site, Polish on the Polish site, and English on the English site.

**Updated `ImplementIdeaDialog.test.tsx`** to mock `next-intl` using the project's standard identity-function pattern, and adjusted test expectations accordingly — all 18 tests pass.

## Commits

- feat: localize ImplementIdea dialog using next-intl translations
- feat: add 30-second polling to ImplementIdeaDialog recent ideas tab