### PR TITLE
V dialogu implement idea, v recent ideas... nemuzu stale rozkliknout zadny hotovy idea a navstivit jeho preview url.... 

### DIFF
--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -26,12 +26,14 @@ jest.mock('../Popup/Popup', () => ({
 }))
 
 jest.mock('../../ui', () => ({
-	Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	Box: ({ children, onClick, title, onKeyDown }: { children: React.ReactNode; onClick?: () => void; title?: string; onKeyDown?: React.KeyboardEventHandler }) => (
+		<div onClick={onClick} title={title} onKeyDown={onKeyDown}>{children}</div>
+	),
 	Button: ({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) => (
 		<button disabled={disabled}>{children}</button>
 	),
-	TextField: ({ disabled }: { disabled?: boolean }) => (
-		<input data-testid="text-field" disabled={disabled} />
+	TextField: ({ disabled, onChange, value }: { disabled?: boolean; onChange?: (v: string) => void; value?: string }) => (
+		<input data-testid="text-field" disabled={disabled} value={value} onChange={e => onChange?.(e.target.value)} />
 	),
 	IconButton: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
 		<button onClick={onClick}>{children}</button>
@@ -92,6 +94,7 @@ describe('ImplementIdeaDialog', () => {
 	beforeEach(() => {
 		jest.clearAllMocks()
 		global.fetch = jest.fn()
+		window.open = jest.fn()
 	})
 
 	afterEach(() => {
@@ -280,6 +283,58 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
 			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
 		})
+
+		it('clicking a task card with previewUrl opens it in new tab', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			process.env.NEXT_PUBLIC_PREVIEW_BASE_URL = 'https://preview.example.com'
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const card = screen.getByTitle('Open in new tab')
+			fireEvent.click(card)
+
+			expect(window.open).toHaveBeenCalledWith('https://preview.example.com/pr-42', '_blank')
+		})
+
+		it('clicking a task card with only a PR URL opens PR in new tab', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			// No NEXT_PUBLIC_PREVIEW_BASE_URL — only PR link available
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const card = screen.getByTitle('Open in new tab')
+			fireEvent.click(card)
+
+			expect(window.open).toHaveBeenCalledWith('https://github.com/org/repo/pull/42', '_blank')
+		})
+
+		it('task card without any URL has no title and does not trigger window.open', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [MOCK_TASKS[0]] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await waitFor(() => screen.getByText(/1 active/))
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByTitle('Open in new tab')).not.toBeInTheDocument()
+
+			const promptEl = screen.getByText('Add dark mode')
+			fireEvent.click(promptEl)
+
+			expect(window.open).not.toHaveBeenCalled()
+		})
 	})
 
 	describe('URL missing state', () => {
@@ -376,6 +431,46 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { jest.advanceTimersByTime(30_000) })
 			await act(async () => { await Promise.resolve() })
 			expect(global.fetch).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('Ctrl+Enter submit', () => {
+		it('shows Ctrl+Enter hint text in submit tab', () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+
+			expect(screen.getByText('Ctrl+Enter to submit')).toBeInTheDocument()
+		})
+
+		it('submits on Ctrl+Enter keydown in textarea wrapper', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			// Use mockResolvedValue (not Once) so all GET and POST fetches resolve without error
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+
+			// Wait for initial fetch to settle
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+
+			// Type something in the text field — updates message state
+			const textField = screen.getByTestId('text-field')
+			fireEvent.change(textField, { target: { value: 'My great idea' } })
+
+			// Fire Ctrl+Enter on the input — bubbles up to the Box wrapper's onKeyDown
+			fireEvent.keyDown(textField, { key: 'Enter', ctrlKey: true })
+
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalledWith(
+					MOCK_URL,
+					expect.objectContaining({ method: 'POST' })
+				)
+			})
 		})
 	})
 })

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -237,6 +237,12 @@ export default function ImplementIdeaDialog({
 						<Gap value={2} />
 
 						<Box
+							onKeyDown={(e: React.KeyboardEvent) => {
+								if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+									e.preventDefault()
+									handleSubmit()
+								}
+							}}
 							sx={{
 								border: '1.5px solid',
 								borderColor: urlMissing ? 'error.light' : alpha(BLUE, 0.45),
@@ -268,7 +274,12 @@ export default function ImplementIdeaDialog({
 							</>
 						)}
 
-						<Gap value={2} />
+						<Gap value={0.5} />
+						<Typography variant="normal" size="0.72rem" color="grey.400" sx={{ textAlign: 'right' }}>
+							Ctrl+Enter to submit
+						</Typography>
+
+						<Gap value={1} />
 
 						<Box sx={{ display: 'flex', justifyContent: 'center' }}>
 							<Button
@@ -313,10 +324,13 @@ export default function ImplementIdeaDialog({
 							const style = STATUS_STYLE[task.status]
 							const pr = task.pullRequests?.[0]
 							const previewUrl = task.previewUrl ?? (pr ? getPreviewUrl(pr.url) : null)
+							const openUrl = previewUrl ?? pr?.url ?? null
 
 							return (
 								<Box
 									key={task.taskId}
+									onClick={() => openUrl && window.open(openUrl, '_blank')}
+									title={openUrl ? 'Open in new tab' : undefined}
 									sx={{
 										display: 'flex',
 										alignItems: 'flex-start',
@@ -326,6 +340,12 @@ export default function ImplementIdeaDialog({
 										bgcolor: 'rgba(255,255,255,0.6)',
 										border: '1px solid',
 										borderColor: alpha('#000', 0.06),
+										cursor: openUrl ? 'pointer' : 'default',
+										transition: 'background 0.15s, border-color 0.15s',
+										'&:hover': openUrl ? {
+											bgcolor: 'rgba(255,255,255,0.9)',
+											borderColor: alpha(BLUE, 0.25),
+										} : undefined,
 									}}
 								>
 									{/* Status chip */}
@@ -367,6 +387,7 @@ export default function ImplementIdeaDialog({
 												rel="noopener noreferrer"
 												title="Open preview"
 												style={{ textDecoration: 'none' }}
+												onClick={(e) => e.stopPropagation()}
 											>
 												<Box
 													sx={{
@@ -399,6 +420,7 @@ export default function ImplementIdeaDialog({
 												rel="noopener noreferrer"
 												title="View GitHub PR"
 												style={{ textDecoration: 'none' }}
+												onClick={(e) => e.stopPropagation()}
 											>
 												<Box
 													sx={{


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

1. **Clickable idea cards** — Each task card in "Recent ideas" is now clickable. Clicking opens the preview URL (or PR URL as fallback) in a new browser tab. Cards show a pointer cursor and a blue highlight on hover when a URL is available. The existing Preview/PR buttons use `stopPropagation` to avoid double-opening.

2. **Ctrl+Enter to submit** — Added a `onKeyDown` handler on the textarea wrapper that triggers `handleSubmit()` when Ctrl+Enter (or Cmd+Enter) is pressed. A subtle "Ctrl+Enter to submit" hint is shown below the textarea. All 20 tests pass and the build succeeded.

## Commits

- feat: make idea cards clickable and add Ctrl+Enter submit shortcut
- feat: localize ImplementIdea dialog using next-intl translations
- feat: add 30-second polling to ImplementIdeaDialog recent ideas tab