### PR TITLE
Projdi jak je delany idea implement dialog... spust testy a build a udelej at vse prochazi.... Proc na devu stale nevidi

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -271,7 +271,7 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
 		})
 
-		it('does not show preview link when NEXT_PUBLIC_PREVIEW_BASE_URL is not set', async () => {
+		it('shows preview link falling back to PR URL when NEXT_PUBLIC_PREVIEW_BASE_URL is not set', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			;(global.fetch as jest.Mock).mockResolvedValue({
 				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
@@ -283,10 +283,54 @@ describe('ImplementIdeaDialog', () => {
 
 			const links = screen.queryAllByRole('link')
 			const hrefs = links.map(l => l.getAttribute('href'))
+			// No generated preview URL (env var not set), but Preview button still shows using PR URL as fallback
 			expect(hrefs).not.toContain(expect.stringContaining('preview.example.com'))
 			expect(hrefs).toContain('https://github.com/org/repo/pull/42')
-			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
+			expect(screen.getByTitle('Open preview')).toBeInTheDocument()
 			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
+		})
+
+		it('shows preview link for completed task with no PR and direct previewUrl', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const completedNoPr = {
+				taskId: '10',
+				status: 'completed',
+				prompt: 'Direct deploy idea',
+				pullRequests: [],
+				previewUrl: 'https://dev.example.com/idea',
+			}
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [completedNoPr] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const links = screen.getAllByRole('link')
+			const hrefs = links.map(l => l.getAttribute('href'))
+			expect(hrefs).toContain('https://dev.example.com/idea')
+			expect(screen.getByTitle('Open preview')).toBeInTheDocument()
+		})
+
+		it('does not show preview link for completed task with no URL at all', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const completedNoUrl = {
+				taskId: '11',
+				status: 'completed',
+				prompt: 'No URL idea',
+				pullRequests: [],
+			}
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [completedNoUrl] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
+			expect(screen.queryByTitle('View GitHub PR')).not.toBeInTheDocument()
 		})
 
 		it('clicking a task card with previewUrl opens it in new tab', async () => {
@@ -330,7 +374,7 @@ describe('ImplementIdeaDialog', () => {
 			})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await waitFor(() => screen.getByText(/1 active/))
+			await waitFor(() => screen.getByText(/recentIdeasTabActive:1/))
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			expect(screen.queryByTitle('Open in new tab')).not.toBeInTheDocument()

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -428,9 +428,9 @@ export default function ImplementIdeaDialog({
 
 									{/* Action buttons */}
 									<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0, alignItems: 'flex-end' }}>
-										{task.status === 'completed' && previewUrl && (
+										{task.status === 'completed' && openUrl && (
 											<a
-												href={previewUrl}
+												href={openUrl}
 												target="_blank"
 												rel="noopener noreferrer"
 												title="Open preview"


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was implemented:

**Preview button fix** (`ImplementIdeaDialog.tsx`): The Preview button for completed tasks now uses `openUrl` (which falls back from `previewUrl` → generated preview URL → PR URL) instead of requiring `previewUrl` to be set. On dev where `NEXT_PUBLIC_PREVIEW_BASE_URL` is not configured, completed tasks with a GitHub PR will now show a clickable Preview button pointing to the PR URL.

**Test fixes** (`ImplementIdeaDialog.test.tsx` + `.env.test`): Fixed a broken test with wrong regex `/1 active/` (should match mock format `recentIdeasTabActive:1`), updated the test that incorrectly expected no Preview button when only a PR URL is available, added 2 new tests for the fallback behavior, and created `.env.test` with `NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000` to fix 2 integration test suites that crashed because the env var was undefined. All 153 tests now pass and the build succeeds.

## Commits

- feat: show Preview button for completed ideas even without preview base URL