### PR TITLE
V implement idea dialogu.... jak je tlacitko na otevreni preivew... udelej, aby se proste vzalo cislo PR z completed tas

### DIFF
--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -309,7 +309,7 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.getByTitle('Open preview')).toBeInTheDocument()
 		})
 
-		it('shows disabled preview button (no link) for completed task with no URL at all', async () => {
+		it('shows active preview link for completed task with no PR, falling back to base preview URL', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			const completedNoUrl = {
 				taskId: '11',
@@ -325,9 +325,11 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			// Preview button is shown but not as a link (disabled state)
-			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
-			expect(screen.getByText('Preview')).toBeInTheDocument()
+			// Preview button is always active for completed tasks, falls back to base URL
+			expect(screen.getByTitle('Open preview')).toBeInTheDocument()
+			const links = screen.getAllByRole('link')
+			const hrefs = links.map(l => l.getAttribute('href'))
+			expect(hrefs).toContain('https://preview.chvalotce.cz')
 			expect(screen.queryByTitle('View GitHub PR')).not.toBeInTheDocument()
 		})
 

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -371,8 +371,12 @@ export default function ImplementIdeaDialog({
 							{tasks.map((task) => {
 							const style = STATUS_STYLE[task.status]
 							const pr = task.pullRequests?.[0]
-							const previewUrl = task.previewUrl ?? (pr ? getPreviewUrl(pr.url) : null)
-							const openUrl = previewUrl ?? pr?.url ?? null
+							const prNumber = pr ? extractPrNumber(pr.url) : null
+							const previewUrl = task.previewUrl ?? (prNumber ? `${PREVIEW_BASE_URL}/pr-${prNumber}` : null)
+							// Completed tasks always get an active preview URL
+							const openUrl = task.status === 'completed'
+								? (previewUrl ?? PREVIEW_BASE_URL)
+								: (previewUrl ?? pr?.url ?? null)
 
 							return (
 								<Box
@@ -429,60 +433,37 @@ export default function ImplementIdeaDialog({
 									{/* Action buttons */}
 									<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0, alignItems: 'flex-end' }}>
 										{task.status === 'completed' && (
-											openUrl ? (
-												<a
-													href={openUrl}
-													target="_blank"
-													rel="noopener noreferrer"
-													title="Open preview"
-													style={{ textDecoration: 'none' }}
-													onClick={(e) => e.stopPropagation()}
-												>
-													<Box
-														sx={{
-															display: 'flex',
-															alignItems: 'center',
-															gap: 0.4,
-															color: BLUE,
-															fontSize: '0.7rem',
-															fontWeight: 700,
-															bgcolor: alpha(BLUE, 0.1),
-															border: '1px solid',
-															borderColor: alpha(BLUE, 0.25),
-															px: 0.75,
-															py: 0.25,
-															borderRadius: 1,
-															whiteSpace: 'nowrap',
-															transition: 'background 0.15s',
-															'&:hover': { bgcolor: alpha(BLUE, 0.18) },
-														}}
-													>
-														<OpenInNew sx={{ fontSize: 11 }} />
-														Preview
-													</Box>
-												</a>
-											) : (
+											<a
+												href={openUrl!}
+												target="_blank"
+												rel="noopener noreferrer"
+												title="Open preview"
+												style={{ textDecoration: 'none' }}
+												onClick={(e) => e.stopPropagation()}
+											>
 												<Box
 													sx={{
 														display: 'flex',
 														alignItems: 'center',
 														gap: 0.4,
-														color: '#aaa',
+														color: BLUE,
 														fontSize: '0.7rem',
 														fontWeight: 700,
-														bgcolor: alpha('#000', 0.04),
+														bgcolor: alpha(BLUE, 0.1),
 														border: '1px solid',
-														borderColor: alpha('#000', 0.1),
+														borderColor: alpha(BLUE, 0.25),
 														px: 0.75,
 														py: 0.25,
 														borderRadius: 1,
 														whiteSpace: 'nowrap',
+														transition: 'background 0.15s',
+														'&:hover': { bgcolor: alpha(BLUE, 0.18) },
 													}}
 												>
 													<OpenInNew sx={{ fontSize: 11 }} />
 													Preview
 												</Box>
-											)
+											</a>
 										)}
 										{pr && (
 											<a


### PR DESCRIPTION
## Summary

Done. The Preview button in the idea dialog is now always active for completed tasks. The URL logic: takes the PR number from `task.pullRequests[0]` and constructs `preview.chvalotce.cz/pr-{number}`, uses `task.previewUrl` if explicitly provided, or falls back to `preview.chvalotce.cz` as the base URL if no PR exists at all. The grayed-out disabled button variant is removed entirely.

## Commits

- feat: always show active Preview button for completed tasks in idea dialog