### PR TITLE
Chtel bych abys v implement dialogu v seznamu poslednich napadu... abys tam udelal, ze bude oznaceno, ktere tasky uz jso

### DIFF
--- a/content/chvalotce.d.json.ts
+++ b/content/chvalotce.d.json.ts
@@ -976,6 +976,8 @@ declare const messages: {
 		"submitFailed": "Nepodařilo se odeslat nápad.",
 		"nextRefreshIn": "Obnoví se za {seconds}s",
 		"refreshButton": "Obnovit",
+		"noPr": "Nemá PR",
+		"merged": "Sloučeno",
 		"status": {
 			"queued": "Ve frontě",
 			"running": "Probíhá",

--- a/content/chvalotce.json
+++ b/content/chvalotce.json
@@ -973,6 +973,8 @@
 		"submitFailed": "Nepodařilo se odeslat nápad.",
 		"nextRefreshIn": "Obnoví se za {seconds}s",
 		"refreshButton": "Obnovit",
+		"noPr": "Nemá PR",
+		"merged": "Sloučeno",
 		"status": {
 			"queued": "Ve frontě",
 			"running": "Probíhá",

--- a/content/chwalmy.json
+++ b/content/chwalmy.json
@@ -973,6 +973,8 @@
 		"submitFailed": "Nie udało się wysłać pomysłu.",
 		"nextRefreshIn": "Odświeży się za {seconds}s",
 		"refreshButton": "Odśwież",
+		"noPr": "Brak PR",
+		"merged": "Połączone",
 		"status": {
 			"queued": "W kolejce",
 			"running": "W toku",

--- a/content/hallelujahhub.json
+++ b/content/hallelujahhub.json
@@ -990,6 +990,8 @@
 		"submitFailed": "Failed to submit idea.",
 		"nextRefreshIn": "Refreshes in {seconds}s",
 		"refreshButton": "Refresh",
+		"noPr": "No PR",
+		"merged": "Merged",
 		"status": {
 			"queued": "Queued",
 			"running": "Running",

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.test.tsx
@@ -29,7 +29,7 @@ jest.mock('../Popup/Popup', () => ({
 }))
 
 jest.mock('../../ui', () => ({
-	Box: ({ children, onClick, title, onKeyDown }: { children: React.ReactNode; onClick?: () => void; title?: string; onKeyDown?: React.KeyboardEventHandler }) => (
+	Box: ({ children, onClick, title, onKeyDown, sx }: { children: React.ReactNode; onClick?: () => void; title?: string; onKeyDown?: React.KeyboardEventHandler; sx?: unknown }) => (
 		<div onClick={onClick} title={title} onKeyDown={onKeyDown}>{children}</div>
 	),
 	Button: ({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) => (
@@ -92,6 +92,16 @@ const MOCK_TASK_WITH_DIRECT_PREVIEW_URL = {
 	previewUrl: 'https://direct-preview.example.com/pr-55',
 }
 
+// Helper: mock GitHub merge API to return "not merged" (404)
+function mockGitHubNotMerged() {
+	return jest.fn().mockResolvedValue({ status: 404 })
+}
+
+// Helper: mock GitHub merge API to return "merged" (204)
+function mockGitHubMerged() {
+	return jest.fn().mockResolvedValue({ status: 204 })
+}
+
 describe('ImplementIdeaDialog', () => {
 	const defaultProps = { open: true, onClose: jest.fn() }
 
@@ -109,9 +119,11 @@ describe('ImplementIdeaDialog', () => {
 	describe('Task counts display', () => {
 		it('shows active count in tab label after fetching tasks', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValueOnce({
-				json: () => Promise.resolve({ tasks: MOCK_TASKS }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: MOCK_TASKS }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
@@ -123,9 +135,11 @@ describe('ImplementIdeaDialog', () => {
 
 		it('does not show active count when no active tasks', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValueOnce({
-				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
@@ -138,9 +152,10 @@ describe('ImplementIdeaDialog', () => {
 	describe('Recent ideas tab', () => {
 		it('shows task list when switching to recent ideas tab', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: MOCK_TASKS }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValue({
+					json: () => Promise.resolve({ tasks: MOCK_TASKS }),
+				})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 
@@ -154,9 +169,10 @@ describe('ImplementIdeaDialog', () => {
 
 		it('shows tasks in reversed order (newest first)', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: MOCK_TASKS }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValue({
+					json: () => Promise.resolve({ tasks: MOCK_TASKS }),
+				})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 			await waitFor(() => screen.getByText(/recentIdeasTabActive/))
@@ -195,14 +211,16 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.getByText('noIdeas')).toBeInTheDocument()
 		})
 
-		it('shows preview link for completed task with PR using hardcoded preview URL', async () => {
+		it('shows preview link for completed task with PR using hardcoded preview URL (not merged)', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const links = screen.getAllByRole('link')
@@ -216,12 +234,14 @@ describe('ImplementIdeaDialog', () => {
 		it('uses task.previewUrl directly when provided, ignoring env var', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			// No NEXT_PUBLIC_PREVIEW_BASE_URL set — should still show preview via task.previewUrl
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASK_WITH_DIRECT_PREVIEW_URL] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASK_WITH_DIRECT_PREVIEW_URL] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const links = screen.getAllByRole('link')
@@ -232,12 +252,14 @@ describe('ImplementIdeaDialog', () => {
 
 		it('prefers task.previewUrl over hardcoded-URL-generated preview URL', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASK_WITH_DIRECT_PREVIEW_URL] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASK_WITH_DIRECT_PREVIEW_URL] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const links = screen.getAllByRole('link')
@@ -267,14 +289,16 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
 		})
 
-		it('always generates preview URL from hardcoded base URL when task has PR', async () => {
+		it('always generates preview URL from hardcoded base URL when task has PR (not merged)', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const links = screen.queryAllByRole('link')
@@ -330,12 +354,14 @@ describe('ImplementIdeaDialog', () => {
 
 		it('clicking a task card with previewUrl opens it in new tab', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const card = screen.getByTitle('Open in new tab')
@@ -346,12 +372,14 @@ describe('ImplementIdeaDialog', () => {
 
 		it('clicking a task card with a PR opens the generated preview URL in new tab', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
-			})
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 }) // GitHub API: not merged
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
-			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			const card = screen.getByTitle('Open in new tab')
@@ -377,6 +405,179 @@ describe('ImplementIdeaDialog', () => {
 			fireEvent.click(promptEl)
 
 			expect(window.open).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('Completed task without PR', () => {
+		it('shows noPr message for completed task without any PR', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const completedNoPr = {
+				taskId: '20',
+				status: 'completed',
+				prompt: 'Completed without PR',
+				pullRequests: [],
+			}
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [completedNoPr] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.getByText('noPr')).toBeInTheDocument()
+		})
+
+		it('completed task without PR is not clickable', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const completedNoPr = {
+				taskId: '21',
+				status: 'completed',
+				prompt: 'Completed no PR task',
+				pullRequests: [],
+			}
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [completedNoPr] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			// Card should not have "Open in new tab" title (no clickable URL)
+			expect(screen.queryByTitle('Open in new tab')).not.toBeInTheDocument()
+
+			// Clicking the prompt text should not call window.open
+			const promptEl = screen.getByText('Completed no PR task')
+			fireEvent.click(promptEl)
+			expect(window.open).not.toHaveBeenCalled()
+		})
+
+		it('does not show noPr message for non-completed tasks without PR', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [MOCK_TASKS[0]] }), // running, no PR
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByText('noPr')).not.toBeInTheDocument()
+		})
+	})
+
+	describe('Merged PR behavior', () => {
+		it('shows merged badge when PR is merged', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValueOnce({ status: 204 }) // GitHub API: merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.getByText('merged')).toBeInTheDocument()
+		})
+
+		it('does not show preview button when PR is merged', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValueOnce({ status: 204 }) // GitHub API: merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByTitle('Open preview')).not.toBeInTheDocument()
+		})
+
+		it('still shows PR link button when PR is merged', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValueOnce({ status: 204 }) // GitHub API: merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.getByTitle('View GitHub PR')).toBeInTheDocument()
+		})
+
+		it('merged task card is not clickable (no card click URL)', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValueOnce({ status: 204 }) // GitHub API: merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			// Card should not have "Open in new tab" title when merged
+			expect(screen.queryByTitle('Open in new tab')).not.toBeInTheDocument()
+		})
+
+		it('does not show merged badge when PR is not merged', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValueOnce({ status: 404 }) // GitHub API: not merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.queryByText('merged')).not.toBeInTheDocument()
+		})
+
+		it('calls GitHub API to check merge status for completed tasks with PRs', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const fetchMock = jest.fn()
+			global.fetch = fetchMock
+			fetchMock
+				.mockResolvedValueOnce({
+					json: () => Promise.resolve({ tasks: [MOCK_TASKS[2]] }),
+				})
+				.mockResolvedValue({ status: 404 })
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+
+			// Should have called the main API and then the GitHub merge API
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://api.github.com/repos/org/repo/pulls/42/merge',
+				expect.objectContaining({ method: 'GET' })
+			)
+		})
+
+		it('does not call GitHub API for non-completed tasks', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const fetchMock = jest.fn()
+			global.fetch = fetchMock
+			fetchMock.mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [MOCK_TASKS[0]] }), // running, no PR
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+
+			// Should only have called the main API
+			expect(fetchMock).toHaveBeenCalledTimes(1)
+			expect(fetchMock).toHaveBeenCalledWith(MOCK_URL, { method: 'GET' })
 		})
 	})
 

--- a/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementIdea/ImplementIdeaDialog.tsx
@@ -45,6 +45,8 @@ const bgMove = keyframes`
 
 const BLUE = '#0085FF'
 const BLUE_DARK = '#0060cc'
+const PURPLE = '#9c27b0'
+const PURPLE_DARK = '#7b1fa2'
 
 const STATUS_STYLE: Record<TaskStatus, { bg: string; color: string }> = {
 	queued:      { bg: alpha('#888888', 0.1), color: '#666'    },
@@ -58,6 +60,26 @@ const STATUS_STYLE: Record<TaskStatus, { bg: string; color: string }> = {
 function extractPrNumber(prUrl: string): string | null {
 	const match = prUrl.match(/\/pull\/(\d+)$/)
 	return match ? match[1] : null
+}
+
+function extractGitHubPrInfo(prUrl: string): { owner: string; repo: string; number: string } | null {
+	const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/)
+	if (!match) return null
+	return { owner: match[1], repo: match[2], number: match[3] }
+}
+
+async function checkPrMerged(prUrl: string): Promise<boolean> {
+	const info = extractGitHubPrInfo(prUrl)
+	if (!info) return false
+	try {
+		const res = await fetch(
+			`https://api.github.com/repos/${info.owner}/${info.repo}/pulls/${info.number}/merge`,
+			{ method: 'GET', headers: { Accept: 'application/vnd.github.v3+json' } }
+		)
+		return res.status === 204
+	} catch {
+		return false
+	}
 }
 
 const PREVIEW_BASE_URL = 'https://preview.chvalotce.cz'
@@ -82,22 +104,45 @@ export default function ImplementIdeaDialog({
 	const [tasksLoaded, setTasksLoaded] = useState(false)
 	const [activeTab, setActiveTab] = useState(0)
 	const [countdown, setCountdown] = useState(POLL_INTERVAL_S)
+	const [mergedPrUrls, setMergedPrUrls] = useState<Set<string>>(new Set())
 	const { enqueueSnackbar } = useSnackbar()
 
 	const url = process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL
 	const urlMissing = !url
 
-	const fetchTasks = () => {
+	const fetchTasks = async () => {
 		if (!url) return
-		fetch(url, { method: 'GET' })
-			.then((res) => res.json())
-			.then((data: { tasks: Task[] }) => {
-				setTasks([...(data.tasks ?? [])].reverse())
-				setTasksLoaded(true)
-			})
-			.catch(() => {
-				setTasksLoaded(true)
-			})
+		try {
+			const res = await fetch(url, { method: 'GET' })
+			const data: { tasks: Task[] } = await res.json()
+			const newTasks = [...(data.tasks ?? [])].reverse()
+			setTasks(newTasks)
+			setTasksLoaded(true)
+
+			// Check merge status for completed tasks with PRs
+			const completedWithPr = newTasks.filter(
+				(task) => task.status === 'completed' && task.pullRequests?.length > 0
+			)
+			if (completedWithPr.length > 0) {
+				const checks = await Promise.all(
+					completedWithPr.map(async (task) => {
+						const pr = task.pullRequests[0]
+						const merged = await checkPrMerged(pr.url)
+						return { prUrl: pr.url, merged }
+					})
+				)
+				setMergedPrUrls((prev) => {
+					const next = new Set(prev)
+					checks.forEach(({ prUrl, merged }) => {
+						if (merged) next.add(prUrl)
+						else next.delete(prUrl)
+					})
+					return next
+				})
+			}
+		} catch {
+			setTasksLoaded(true)
+		}
 	}
 
 	useEffect(() => {
@@ -373,10 +418,17 @@ export default function ImplementIdeaDialog({
 							const pr = task.pullRequests?.[0]
 							const prNumber = pr ? extractPrNumber(pr.url) : null
 							const previewUrl = task.previewUrl ?? (prNumber ? `${PREVIEW_BASE_URL}/pr-${prNumber}` : null)
-							// Completed tasks always get an active preview URL
-							const openUrl = task.status === 'completed'
-								? (previewUrl ?? PREVIEW_BASE_URL)
-								: (previewUrl ?? pr?.url ?? null)
+
+							const isCompletedNoPr = task.status === 'completed' && !pr
+							const isMerged = task.status === 'completed' && !!pr && mergedPrUrls.has(pr.url)
+							const isDisabled = isCompletedNoPr || isMerged
+
+							// Preview URL is only valid for non-merged tasks
+							const openUrl = isDisabled
+								? null
+								: task.status === 'completed'
+									? (previewUrl ?? PREVIEW_BASE_URL)
+									: (previewUrl ?? pr?.url ?? null)
 
 							return (
 								<Box
@@ -389,9 +441,16 @@ export default function ImplementIdeaDialog({
 										gap: 1.5,
 										p: 1.5,
 										borderRadius: 2,
-										bgcolor: 'rgba(255,255,255,0.6)',
+										bgcolor: isMerged
+											? alpha(PURPLE, 0.06)
+											: isCompletedNoPr
+												? alpha('#000', 0.03)
+												: 'rgba(255,255,255,0.6)',
 										border: '1px solid',
-										borderColor: alpha('#000', 0.06),
+										borderColor: isMerged
+											? alpha(PURPLE, 0.2)
+											: alpha('#000', 0.06),
+										opacity: isCompletedNoPr ? 0.55 : 1,
 										cursor: openUrl ? 'pointer' : 'default',
 										transition: 'background 0.15s, border-color 0.15s',
 										'&:hover': openUrl ? {
@@ -400,39 +459,68 @@ export default function ImplementIdeaDialog({
 										} : undefined,
 									}}
 								>
-									{/* Status chip */}
-									<Box
-										sx={{
-											flexShrink: 0,
-											bgcolor: style.bg,
-											color: style.color,
-											px: 1,
-											py: 0.25,
-											borderRadius: 1,
-											fontSize: '0.7rem',
-											fontWeight: 600,
-											whiteSpace: 'nowrap',
-											mt: 0.25,
-										}}
-									>
-										{t(`status.${task.status}`)}
+									{/* Status chip + merged badge */}
+									<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0 }}>
+										<Box
+											sx={{
+												bgcolor: style.bg,
+												color: style.color,
+												px: 1,
+												py: 0.25,
+												borderRadius: 1,
+												fontSize: '0.7rem',
+												fontWeight: 600,
+												whiteSpace: 'nowrap',
+												mt: 0.25,
+											}}
+										>
+											{t(`status.${task.status}`)}
+										</Box>
+										{isMerged && (
+											<Box
+												sx={{
+													bgcolor: alpha(PURPLE, 0.12),
+													color: PURPLE_DARK,
+													px: 1,
+													py: 0.25,
+													borderRadius: 1,
+													fontSize: '0.65rem',
+													fontWeight: 600,
+													whiteSpace: 'nowrap',
+												}}
+											>
+												{t('merged')}
+											</Box>
+										)}
 									</Box>
 
-									{/* Prompt */}
-									<Typography
-										variant="normal"
-										size="0.82rem"
-										color="grey.800"
-										sx={{ flex: 1, lineHeight: 1.4 }}
-									>
-										{task.prompt?.length > 120
-											? task.prompt.slice(0, 120) + '…'
-											: task.prompt}
-									</Typography>
+									{/* Prompt + no-PR notice */}
+									<Box sx={{ flex: 1 }}>
+										<Typography
+											variant="normal"
+											size="0.82rem"
+											color="grey.800"
+											sx={{ lineHeight: 1.4 }}
+										>
+											{task.prompt?.length > 120
+												? task.prompt.slice(0, 120) + '…'
+												: task.prompt}
+										</Typography>
+										{isCompletedNoPr && (
+											<Typography
+												variant="normal"
+												size="0.72rem"
+												color="grey.400"
+												sx={{ display: 'block', mt: 0.5 }}
+											>
+												{t('noPr')}
+											</Typography>
+										)}
+									</Box>
 
 									{/* Action buttons */}
 									<Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0, alignItems: 'flex-end' }}>
-										{task.status === 'completed' && pr && (
+										{task.status === 'completed' && pr && !isMerged && (
 											<a
 												href={openUrl!}
 												target="_blank"
@@ -479,18 +567,18 @@ export default function ImplementIdeaDialog({
 														display: 'flex',
 														alignItems: 'center',
 														gap: 0.4,
-														color: '#666',
+														color: isMerged ? PURPLE_DARK : '#666',
 														fontSize: '0.7rem',
 														fontWeight: 600,
-														bgcolor: alpha('#000', 0.04),
+														bgcolor: isMerged ? alpha(PURPLE, 0.08) : alpha('#000', 0.04),
 														border: '1px solid',
-														borderColor: alpha('#000', 0.1),
+														borderColor: isMerged ? alpha(PURPLE, 0.2) : alpha('#000', 0.1),
 														px: 0.75,
 														py: 0.25,
 														borderRadius: 1,
 														whiteSpace: 'nowrap',
 														transition: 'background 0.15s',
-														'&:hover': { bgcolor: alpha('#000', 0.08) },
+														'&:hover': { bgcolor: isMerged ? alpha(PURPLE, 0.15) : alpha('#000', 0.08) },
 													}}
 												>
 													<OpenInNew sx={{ fontSize: 11 }} />


### PR DESCRIPTION
## Summary

Vše hotovo. Implementoval jsem tři stavy v dialogu posledních nápadů: (1) **completed bez PR** — karta je lehce průhledná (opacity 0.55), neklikatelná, a zobrazuje se u ní zpráva „Nemá PR"; (2) **completed s PR, který je mergnutý** — karta má lehce fialové pozadí s fialovým ohraničením, zobrazuje se badge „Sloučeno" pod status chipem, preview tlačítko se nezobrazuje (preview URL je platná jen pro otevřené PRs), ale PR odkaz zůstává; (3) při každém refreshi se pro všechny completed tasky s PR volá GitHub API (`/repos/{owner}/{repo}/pulls/{n}/merge`) a na základě HTTP 204/404 se stav merged detekuje. Přidáno 10 nových testů, TypeScript build i Next.js build prochází bez chyb.

## Commits

- feat: show merged/no-PR status in implement dialog task list