### PR TITLE
Pridej do implementIdea dialogu k poslednim napadu filtrovani, ktere ukaze jen tasky, ktere maji stale otevrene PR

### DIFF
--- a/content/chvalotce.d.json.ts
+++ b/content/chvalotce.d.json.ts
@@ -995,7 +995,9 @@ declare const messages: {
 		"nextRefreshIn": "Obnoví se za {seconds}s",
 		"refreshButton": "Obnovit",
 		"noPr": "Nemá PR",
-		"merged": "Sloučeno"
+		"merged": "Sloučeno",
+		"filterOpenPr": "Jen otevřené PR",
+		"noIdeasWithOpenPr": "Žádné nápady s otevřenými PR"
 	}
 };
 export default messages;

--- a/content/chvalotce.json
+++ b/content/chvalotce.json
@@ -992,6 +992,8 @@
 		"nextRefreshIn": "Obnoví se za {seconds}s",
 		"refreshButton": "Obnovit",
 		"noPr": "Nemá PR",
-		"merged": "Sloučeno"
+		"merged": "Sloučeno",
+		"filterOpenPr": "Jen otevřené PR",
+		"noIdeasWithOpenPr": "Žádné nápady s otevřenými PR"
 	}
 }

--- a/content/chwalmy.json
+++ b/content/chwalmy.json
@@ -992,6 +992,8 @@
 		"nextRefreshIn": "Odświeży się za {seconds}s",
 		"refreshButton": "Odśwież",
 		"noPr": "Brak PR",
-		"merged": "Połączone"
+		"merged": "Połączone",
+		"filterOpenPr": "Tylko otwarte PR",
+		"noIdeasWithOpenPr": "Brak pomysłów z otwartymi PR"
 	}
 }

--- a/content/hallelujahhub.json
+++ b/content/hallelujahhub.json
@@ -1009,6 +1009,8 @@
 		"nextRefreshIn": "Refreshes in {seconds}s",
 		"refreshButton": "Refresh",
 		"noPr": "No PR",
-		"merged": "Merged"
+		"merged": "Merged",
+		"filterOpenPr": "Open PRs only",
+		"noIdeasWithOpenPr": "No ideas with open PRs"
 	}
 }

--- a/src/common/components/ImplementAndPreview/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementAndPreview/ImplementIdeaDialog.test.tsx
@@ -33,8 +33,8 @@ jest.mock('../Popup/Popup', () => ({
 }))
 
 jest.mock('../../ui', () => ({
-	Box: ({ children, onClick, title, onKeyDown, sx }: { children: React.ReactNode; onClick?: () => void; title?: string; onKeyDown?: React.KeyboardEventHandler; sx?: unknown }) => (
-		<div onClick={onClick} title={title} onKeyDown={onKeyDown}>{children}</div>
+	Box: ({ children, onClick, title, onKeyDown, role, 'aria-pressed': ariaPressed }: { children: React.ReactNode; onClick?: () => void; title?: string; onKeyDown?: React.KeyboardEventHandler; sx?: unknown; role?: string; 'aria-pressed'?: boolean }) => (
+		<div onClick={onClick} title={title} onKeyDown={onKeyDown} role={role} aria-pressed={ariaPressed}>{children}</div>
 	),
 	Button: ({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) => (
 		<button disabled={disabled}>{children}</button>
@@ -853,6 +853,202 @@ describe('ImplementIdeaDialog', () => {
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
 			expect(screen.getByText('My prompt text')).toBeInTheDocument()
+		})
+	})
+
+	describe('Open PR filter', () => {
+		const TASKS_MIXED = [
+			{
+				taskId: 'f1',
+				status: 'running',
+				prompt: 'Running task no PR',
+				pullRequests: [],
+			},
+			{
+				taskId: 'f2',
+				status: 'completed',
+				prompt: 'Completed with open PR',
+				pullRequests: [{ repo: 'r', url: 'https://github.com/org/repo/pull/10', state: 'open' }],
+				previewUrl: 'https://preview.chvalotce.cz/pr-10',
+			},
+			{
+				taskId: 'f3',
+				status: 'completed',
+				prompt: 'Completed with closed PR',
+				pullRequests: [{ repo: 'r', url: 'https://github.com/org/repo/pull/11', state: 'closed' }],
+			},
+			{
+				taskId: 'f4',
+				status: 'completed',
+				prompt: 'Completed no PR',
+				pullRequests: [],
+			},
+		]
+
+		it('shows filter toggle chip in recent ideas tab', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.getByText('filterOpenPr')).toBeInTheDocument()
+		})
+
+		it('filter chip is inactive by default (aria-pressed=false)', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			expect(filterBtn).toHaveAttribute('aria-pressed', 'false')
+		})
+
+		it('toggling filter activates it (aria-pressed=true)', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			fireEvent.click(filterBtn)
+
+			expect(filterBtn).toHaveAttribute('aria-pressed', 'true')
+		})
+
+		it('shows all tasks when filter is off', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({ json: () => Promise.resolve({ tasks: TASKS_MIXED }) })
+				.mockResolvedValue({ status: 404 })
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			expect(screen.getByText('Running task no PR')).toBeInTheDocument()
+			expect(screen.getByText('Completed with open PR')).toBeInTheDocument()
+			expect(screen.getByText('Completed with closed PR')).toBeInTheDocument()
+			expect(screen.getByText('Completed no PR')).toBeInTheDocument()
+		})
+
+		it('shows only tasks with open (non-merged) PRs when filter is on', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({ json: () => Promise.resolve({ tasks: TASKS_MIXED }) })
+				.mockResolvedValue({ status: 404 }) // all PRs not merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			fireEvent.click(filterBtn)
+
+			// Only the task with open PR should be shown
+			expect(screen.getByText('Completed with open PR')).toBeInTheDocument()
+			// Others should be hidden
+			expect(screen.queryByText('Running task no PR')).not.toBeInTheDocument()
+			expect(screen.queryByText('Completed with closed PR')).not.toBeInTheDocument()
+			expect(screen.queryByText('Completed no PR')).not.toBeInTheDocument()
+		})
+
+		it('shows noIdeasWithOpenPr message when filter is on and no tasks have open PRs', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const noOpenPrTasks = [
+				{ taskId: 'x1', status: 'running', prompt: 'Running task', pullRequests: [] },
+				{ taskId: 'x2', status: 'completed', prompt: 'Done no PR', pullRequests: [] },
+			]
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: noOpenPrTasks }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			fireEvent.click(filterBtn)
+
+			expect(screen.getByText('noIdeasWithOpenPr')).toBeInTheDocument()
+			expect(screen.queryByText('noIdeas')).not.toBeInTheDocument()
+		})
+
+		it('does not show noIdeasWithOpenPr when total tasks is zero (shows noIdeas instead)', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: [] }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			fireEvent.click(filterBtn)
+
+			expect(screen.getByText('noIdeas')).toBeInTheDocument()
+			expect(screen.queryByText('noIdeasWithOpenPr')).not.toBeInTheDocument()
+		})
+
+		it('excludes merged PRs from filtered results', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const mergedPrTask = {
+				taskId: 'm1',
+				status: 'completed',
+				prompt: 'Merged PR task',
+				pullRequests: [{ repo: 'r', url: 'https://github.com/org/repo/pull/77', state: 'open' }],
+				previewUrl: 'https://preview.chvalotce.cz/pr-77',
+			}
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({ json: () => Promise.resolve({ tasks: [mergedPrTask] }) })
+				.mockResolvedValue({ status: 204 }) // GitHub: merged
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			fireEvent.click(filterBtn)
+
+			// Merged task should be excluded from open PR filter
+			expect(screen.queryByText('Merged PR task')).not.toBeInTheDocument()
+			expect(screen.getByText('noIdeasWithOpenPr')).toBeInTheDocument()
+		})
+
+		it('toggling filter off restores all tasks', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			;(global.fetch as jest.Mock)
+				.mockResolvedValueOnce({ json: () => Promise.resolve({ tasks: TASKS_MIXED }) })
+				.mockResolvedValue({ status: 404 })
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+
+			// Enable filter
+			fireEvent.click(filterBtn)
+			expect(screen.queryByText('Running task no PR')).not.toBeInTheDocument()
+
+			// Disable filter
+			fireEvent.click(filterBtn)
+			expect(screen.getByText('Running task no PR')).toBeInTheDocument()
+			expect(screen.getByText('Completed with open PR')).toBeInTheDocument()
+			expect(screen.getByText('Completed with closed PR')).toBeInTheDocument()
 		})
 	})
 

--- a/src/common/components/ImplementAndPreview/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementAndPreview/ImplementIdeaDialog.tsx
@@ -77,6 +77,7 @@ export default function ImplementIdeaDialog({
 	const [activeTab, setActiveTab] = useState(0)
 	const [countdown, setCountdown] = useState(POLL_INTERVAL_S)
 	const [mergedPrUrls, setMergedPrUrls] = useState<Set<string>>(new Set())
+	const [filterOpenPr, setFilterOpenPr] = useState(false)
 	const { enqueueSnackbar } = useSnackbar()
 
 	const url = process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL
@@ -233,6 +234,13 @@ export default function ImplementIdeaDialog({
 		(t) => ACTIVE_STATUSES.includes((t.displayStatus ?? t.status) as TaskStatus)
 	).length
 	const queuedCount = tasks.filter((t) => (t.displayStatus ?? t.status) === 'queued').length
+
+	const displayedTasks = filterOpenPr
+		? tasks.filter((task) => {
+				const pr = task.pullRequests?.[0]
+				return pr && pr.state === 'open' && !mergedPrUrls.has(pr.url)
+		  })
+		: tasks
 
 	return (
 		<Popup
@@ -394,26 +402,58 @@ export default function ImplementIdeaDialog({
 							gap: 1,
 						}}
 					>
-						{/* Refresh bar */}
+						{/* Toolbar: filter + refresh */}
 						<Box
 							sx={{
 								display: 'flex',
 								alignItems: 'center',
-								justifyContent: 'flex-end',
+								justifyContent: 'space-between',
 								gap: 1,
 								mb: 0.25,
 							}}
 						>
-							<Typography variant="normal" size="0.72rem" color="grey.400">
-								{t('nextRefreshIn', { seconds: String(countdown) })}
-							</Typography>
-							<IconButton
-								small
-								onClick={handleRefresh}
-								aria-label={t('refreshButton')}
+							{/* Filter toggle chip */}
+							<Box
+								onClick={() => setFilterOpenPr((v) => !v)}
+								aria-pressed={filterOpenPr}
+								role="button"
+								sx={{
+									display: 'inline-flex',
+									alignItems: 'center',
+									cursor: 'pointer',
+									px: 1,
+									py: 0.3,
+									borderRadius: 1.5,
+									fontSize: '0.72rem',
+									fontWeight: 600,
+									border: '1px solid',
+									bgcolor: filterOpenPr ? alpha(BLUE, 0.12) : 'transparent',
+									borderColor: filterOpenPr ? alpha(BLUE, 0.3) : alpha('#000', 0.12),
+									color: filterOpenPr ? BLUE : 'grey.500',
+									transition: 'all 0.15s',
+									userSelect: 'none',
+									'&:hover': {
+										borderColor: alpha(BLUE, 0.3),
+										bgcolor: filterOpenPr ? alpha(BLUE, 0.16) : alpha(BLUE, 0.04),
+									},
+								}}
 							>
-								<Refresh fontSize="inherit" />
-							</IconButton>
+								{t('filterOpenPr')}
+							</Box>
+
+							{/* Countdown + refresh */}
+							<Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+								<Typography variant="normal" size="0.72rem" color="grey.400">
+									{t('nextRefreshIn', { seconds: String(countdown) })}
+								</Typography>
+								<IconButton
+									small
+									onClick={handleRefresh}
+									aria-label={t('refreshButton')}
+								>
+									<Refresh fontSize="inherit" />
+								</IconButton>
+							</Box>
 						</Box>
 
 						<Box
@@ -437,7 +477,13 @@ export default function ImplementIdeaDialog({
 								</Typography>
 							)}
 
-							{tasks.map((task) => {
+							{tasksLoaded && tasks.length > 0 && displayedTasks.length === 0 && (
+								<Typography variant="normal" size="0.85rem" color="grey.500" align="center">
+									{t('noIdeasWithOpenPr')}
+								</Typography>
+							)}
+
+							{displayedTasks.map((task) => {
 							const effectiveStatus = task.displayStatus ?? task.status
 							const style = STATUS_STYLE[effectiveStatus]
 							const pr = task.pullRequests?.[0]


### PR DESCRIPTION
## Summary

A toggle chip filter ("Open PRs only" / "Jen otevřené PR" / "Tylko otwarte PR") was added to the toolbar area of the Recent Ideas tab in `ImplementIdeaDialog`. When active, the filter shows only tasks whose first PR has `state: 'open'` and is not yet merged; tasks with no PR, closed PRs, or merged PRs are hidden, and a dedicated empty state message (`noIdeasWithOpenPr`) is displayed if the filter yields no results. All 9 new tests and the full 53-test suite pass, and the Next.js build is clean.

## Commits

- feat(implement-idea): add open PR filter to recent ideas tab