### PR TITLE
Udelej, aby prochazeli vsechny jest testy

### DIFF
--- a/src/common/components/ImplementAndPreview/PreviewModeDialog.test.tsx
+++ b/src/common/components/ImplementAndPreview/PreviewModeDialog.test.tsx
@@ -84,6 +84,7 @@ describe('PreviewModeDialog', () => {
 	const defaultProps = { open: true, onClose: jest.fn() }
 
 	beforeEach(() => {
+		process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = 'http://test-api/tasks'
 		jest.clearAllMocks()
 		jest.useFakeTimers()
 		mockFetchWithTasks()
@@ -91,6 +92,10 @@ describe('PreviewModeDialog', () => {
 
 	afterEach(() => {
 		jest.useRealTimers()
+	})
+
+	afterAll(() => {
+		delete process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL
 	})
 
 	it('shows loading spinner initially', () => {


### PR DESCRIPTION
## Summary

All 229 tests now pass (previously 10 were failing). The root cause was that `PreviewModeDialog.test.tsx` mocked `global.fetch` but didn't set `process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL`, which caused `fetchTasks()` to return early (the component guards with `if (!url || !prNumber) return`), leaving `initialLoading` permanently `true` and blocking all subsequent assertions. The fix adds `process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = 'http://test-api/tasks'` in `beforeEach` and cleans it up in `afterAll`.

## Commits

- test: fix PreviewModeDialog tests by setting required env variable