### PR TITLE
V implement idea dialogu v poslednich napadech jak mame filtrovani de otevrenych PRs... udelej, aby to filtrovalo otevre

### DIFF
--- a/content/chvalotce.json
+++ b/content/chvalotce.json
@@ -993,7 +993,7 @@
 		"refreshButton": "Obnovit",
 		"noPr": "Nemá PR",
 		"merged": "Sloučeno",
-		"filterOpenPr": "Jen otevřené PR",
-		"noIdeasWithOpenPr": "Žádné nápady s otevřenými PR"
+		"filterActive": "Aktivní & otevřené PR",
+		"noActiveOrOpenPr": "Žádné aktivní úlohy ani otevřené PR"
 	}
 }

--- a/content/chwalmy.json
+++ b/content/chwalmy.json
@@ -993,7 +993,7 @@
 		"refreshButton": "Odśwież",
 		"noPr": "Brak PR",
 		"merged": "Połączone",
-		"filterOpenPr": "Tylko otwarte PR",
-		"noIdeasWithOpenPr": "Brak pomysłów z otwartymi PR"
+		"filterActive": "Aktywne i otwarte PR",
+		"noActiveOrOpenPr": "Brak aktywnych zadań ani otwartych PR"
 	}
 }

--- a/content/hallelujahhub.json
+++ b/content/hallelujahhub.json
@@ -1010,7 +1010,7 @@
 		"refreshButton": "Refresh",
 		"noPr": "No PR",
 		"merged": "Merged",
-		"filterOpenPr": "Open PRs only",
-		"noIdeasWithOpenPr": "No ideas with open PRs"
+		"filterActive": "Active & open PRs",
+		"noActiveOrOpenPr": "No active tasks or open PRs"
 	}
 }

--- a/src/common/components/ImplementAndPreview/ImplementIdeaDialog.test.tsx
+++ b/src/common/components/ImplementAndPreview/ImplementIdeaDialog.test.tsx
@@ -895,7 +895,7 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			expect(screen.getByText('filterOpenPr')).toBeInTheDocument()
+			expect(screen.getByText('filterActive')).toBeInTheDocument()
 		})
 
 		it('filter chip is inactive by default (aria-pressed=false)', async () => {
@@ -908,7 +908,7 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			expect(filterBtn).toHaveAttribute('aria-pressed', 'false')
 		})
 
@@ -922,7 +922,7 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			fireEvent.click(filterBtn)
 
 			expect(filterBtn).toHaveAttribute('aria-pressed', 'true')
@@ -944,7 +944,7 @@ describe('ImplementIdeaDialog', () => {
 			expect(screen.getByText('Completed no PR')).toBeInTheDocument()
 		})
 
-		it('shows only tasks with open (non-merged) PRs when filter is on', async () => {
+		it('shows active tasks and tasks with open (non-merged) PRs when filter is on', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			;(global.fetch as jest.Mock)
 				.mockResolvedValueOnce({ json: () => Promise.resolve({ tasks: TASKS_MIXED }) })
@@ -954,39 +954,41 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			fireEvent.click(filterBtn)
 
-			// Only the task with open PR should be shown
+			// Active task (running) should be shown even without a PR
+			expect(screen.getByText('Running task no PR')).toBeInTheDocument()
+			// Task with open PR should also be shown
 			expect(screen.getByText('Completed with open PR')).toBeInTheDocument()
-			// Others should be hidden
-			expect(screen.queryByText('Running task no PR')).not.toBeInTheDocument()
+			// Non-active tasks without open PRs should be hidden
 			expect(screen.queryByText('Completed with closed PR')).not.toBeInTheDocument()
 			expect(screen.queryByText('Completed no PR')).not.toBeInTheDocument()
 		})
 
-		it('shows noIdeasWithOpenPr message when filter is on and no tasks have open PRs', async () => {
+		it('shows noActiveOrOpenPr message when filter is on and no tasks are active or have open PRs', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
-			const noOpenPrTasks = [
-				{ taskId: 'x1', status: 'running', prompt: 'Running task', pullRequests: [] },
-				{ taskId: 'x2', status: 'completed', prompt: 'Done no PR', pullRequests: [] },
+			// Only completed/failed tasks with no open PRs — neither active nor open PR
+			const inactiveTasks = [
+				{ taskId: 'x1', status: 'completed', prompt: 'Done no PR', pullRequests: [] },
+				{ taskId: 'x2', status: 'failed', prompt: 'Failed task', pullRequests: [] },
 			]
 			;(global.fetch as jest.Mock).mockResolvedValue({
-				json: () => Promise.resolve({ tasks: noOpenPrTasks }),
+				json: () => Promise.resolve({ tasks: inactiveTasks }),
 			})
 
 			render(<ImplementIdeaDialog {...defaultProps} />)
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			fireEvent.click(filterBtn)
 
-			expect(screen.getByText('noIdeasWithOpenPr')).toBeInTheDocument()
+			expect(screen.getByText('noActiveOrOpenPr')).toBeInTheDocument()
 			expect(screen.queryByText('noIdeas')).not.toBeInTheDocument()
 		})
 
-		it('does not show noIdeasWithOpenPr when total tasks is zero (shows noIdeas instead)', async () => {
+		it('does not show noActiveOrOpenPr when total tasks is zero (shows noIdeas instead)', async () => {
 			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
 			;(global.fetch as jest.Mock).mockResolvedValue({
 				json: () => Promise.resolve({ tasks: [] }),
@@ -996,11 +998,36 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			fireEvent.click(filterBtn)
 
 			expect(screen.getByText('noIdeas')).toBeInTheDocument()
-			expect(screen.queryByText('noIdeasWithOpenPr')).not.toBeInTheDocument()
+			expect(screen.queryByText('noActiveOrOpenPr')).not.toBeInTheDocument()
+		})
+
+		it('shows queued and retrying tasks when filter is on (all active statuses)', async () => {
+			process.env.NEXT_PUBLIC_IMPLEMENT_IDEA_URL = MOCK_URL
+			const activeTasks = [
+				{ taskId: 'a1', status: 'queued', prompt: 'Queued task', pullRequests: [] },
+				{ taskId: 'a2', status: 'retrying', prompt: 'Retrying task', pullRequests: [] },
+				{ taskId: 'a3', status: 'interrupted', prompt: 'Interrupted task', pullRequests: [] },
+			]
+			;(global.fetch as jest.Mock).mockResolvedValue({
+				json: () => Promise.resolve({ tasks: activeTasks }),
+			})
+
+			render(<ImplementIdeaDialog {...defaultProps} />)
+			await act(async () => { await new Promise(r => setTimeout(r, 50)) })
+			fireEvent.click(screen.getAllByRole('tab')[1])
+
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
+			fireEvent.click(filterBtn)
+
+			// Active statuses should be shown
+			expect(screen.getByText('Queued task')).toBeInTheDocument()
+			expect(screen.getByText('Retrying task')).toBeInTheDocument()
+			// Interrupted is not active
+			expect(screen.queryByText('Interrupted task')).not.toBeInTheDocument()
 		})
 
 		it('excludes merged PRs from filtered results', async () => {
@@ -1020,12 +1047,12 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 			fireEvent.click(filterBtn)
 
 			// Merged task should be excluded from open PR filter
 			expect(screen.queryByText('Merged PR task')).not.toBeInTheDocument()
-			expect(screen.getByText('noIdeasWithOpenPr')).toBeInTheDocument()
+			expect(screen.getByText('noActiveOrOpenPr')).toBeInTheDocument()
 		})
 
 		it('toggling filter off restores all tasks', async () => {
@@ -1038,13 +1065,14 @@ describe('ImplementIdeaDialog', () => {
 			await act(async () => { await new Promise(r => setTimeout(r, 100)) })
 			fireEvent.click(screen.getAllByRole('tab')[1])
 
-			const filterBtn = screen.getByRole('button', { name: 'filterOpenPr' })
+			const filterBtn = screen.getByRole('button', { name: 'filterActive' })
 
-			// Enable filter
+			// Enable filter — non-active tasks without open PRs should be hidden
 			fireEvent.click(filterBtn)
-			expect(screen.queryByText('Running task no PR')).not.toBeInTheDocument()
+			expect(screen.queryByText('Completed with closed PR')).not.toBeInTheDocument()
+			expect(screen.queryByText('Completed no PR')).not.toBeInTheDocument()
 
-			// Disable filter
+			// Disable filter — all tasks restored
 			fireEvent.click(filterBtn)
 			expect(screen.getByText('Running task no PR')).toBeInTheDocument()
 			expect(screen.getByText('Completed with open PR')).toBeInTheDocument()

--- a/src/common/components/ImplementAndPreview/ImplementIdeaDialog.tsx
+++ b/src/common/components/ImplementAndPreview/ImplementIdeaDialog.tsx
@@ -230,6 +230,7 @@ export default function ImplementIdeaDialog({
 	}
 
 	const ACTIVE_STATUSES: TaskStatus[] = ['running', 'starting', 'retrying']
+	const FILTER_ACTIVE_STATUSES: TaskStatus[] = ['queued', 'starting', 'running', 'retrying']
 	const inProgressCount = tasks.filter(
 		(t) => ACTIVE_STATUSES.includes((t.displayStatus ?? t.status) as TaskStatus)
 	).length
@@ -237,8 +238,11 @@ export default function ImplementIdeaDialog({
 
 	const displayedTasks = filterOpenPr
 		? tasks.filter((task) => {
+				const effectiveStatus = task.displayStatus ?? task.status
+				const isActive = FILTER_ACTIVE_STATUSES.includes(effectiveStatus as TaskStatus)
 				const pr = task.pullRequests?.[0]
-				return pr && pr.state === 'open' && !mergedPrUrls.has(pr.url)
+				const hasOpenPr = pr && pr.state === 'open' && !mergedPrUrls.has(pr.url)
+				return isActive || hasOpenPr
 		  })
 		: tasks
 
@@ -438,7 +442,7 @@ export default function ImplementIdeaDialog({
 									},
 								}}
 							>
-								{t('filterOpenPr')}
+								{t('filterActive')}
 							</Box>
 
 							{/* Countdown + refresh */}
@@ -479,7 +483,7 @@ export default function ImplementIdeaDialog({
 
 							{tasksLoaded && tasks.length > 0 && displayedTasks.length === 0 && (
 								<Typography variant="normal" size="0.85rem" color="grey.500" align="center">
-									{t('noIdeasWithOpenPr')}
+									{t('noActiveOrOpenPr')}
 								</Typography>
 							)}
 


### PR DESCRIPTION
## Summary

The filter button in the Recent Ideas dialog now uses an OR condition: when active, it shows tasks that are either in an active state (queued, starting, running, retrying) **or** have an open (non-merged) PR. Translation keys were renamed from `filterOpenPr`/`noIdeasWithOpenPr` to `filterActive`/`noActiveOrOpenPr` with updated labels ("Aktivní & otevřené PR" in Czech) across all three locales. All 54 tests pass and the build is clean.

## Commits

- feat: combine active tasks and open PRs in ideas dialog filter
- Pridej pro admina moznost do admin menu... pridej moznost rychle se prihlasit jako nove vytvoreny uzivatel... Chci aby t (#470)
- test: fix PreviewModeDialog tests by setting required env variable (#468)