### PR TITLE
Proc mi na pull request z devu na master neprochazi preview build ci: 

### DIFF
--- a/src/common/providers/FeatureFlags/FeatureFlagsProvider.test.tsx
+++ b/src/common/providers/FeatureFlags/FeatureFlagsProvider.test.tsx
@@ -1,0 +1,98 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render } from '@testing-library/react'
+
+// Mock dependencies
+const mockUpdateUserAsync = jest.fn()
+const mockClient = { updateUserAsync: mockUpdateUserAsync }
+
+jest.mock('@statsig/react-bindings', () => ({
+	StatsigProvider: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="statsig-provider">{children}</div>
+	),
+	useClientAsyncInit: jest.fn(() => ({ client: mockClient })),
+}))
+
+jest.mock('@statsig/session-replay', () => ({
+	StatsigSessionReplayPlugin: jest.fn(),
+}))
+
+jest.mock('@statsig/web-analytics', () => ({
+	StatsigAutoCapturePlugin: jest.fn(),
+}))
+
+jest.mock('../../../hooks/auth/useAuth', () => ({
+	__esModule: true,
+	default: jest.fn(() => ({ user: null })),
+}))
+
+jest.mock('./flags.tech', () => ({
+	getEnvironmentStatsigConfig: jest.fn(() => ({
+		environment: { tier: 'development' },
+	})),
+	userDtoToStatsigUser: jest.fn((user: { guid?: string } | undefined) => ({
+		userID: user?.guid,
+	})),
+}))
+
+import { FeatureFlagsProvider } from './FeatureFlagsProvider'
+import { useClientAsyncInit } from '@statsig/react-bindings'
+import { StatsigAutoCapturePlugin } from '@statsig/web-analytics'
+import { StatsigSessionReplayPlugin } from '@statsig/session-replay'
+
+describe('FeatureFlagsProvider', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('renders children inside StatsigProvider', () => {
+		const { getByText } = render(
+			<FeatureFlagsProvider>
+				<span>Test Child</span>
+			</FeatureFlagsProvider>
+		)
+
+		expect(getByText('Test Child')).toBeInTheDocument()
+	})
+
+	it('includes browser plugins when window is defined (client-side)', () => {
+		render(
+			<FeatureFlagsProvider>
+				<span>Test</span>
+			</FeatureFlagsProvider>
+		)
+
+		// In jsdom test environment, typeof window !== 'undefined' is true
+		const call = (useClientAsyncInit as jest.Mock).mock.calls[0]
+		const options = call[2]
+
+		expect(options.plugins).toHaveLength(2)
+		expect(StatsigAutoCapturePlugin).toHaveBeenCalled()
+		expect(StatsigSessionReplayPlugin).toHaveBeenCalled()
+	})
+
+	it('passes NEXT_PUBLIC_STATSIG_API_KEY as the first argument', () => {
+		render(
+			<FeatureFlagsProvider>
+				<span>Test</span>
+			</FeatureFlagsProvider>
+		)
+
+		const call = (useClientAsyncInit as jest.Mock).mock.calls[0]
+		// First argument is the API key from env
+		expect(call[0]).toBe(process.env.NEXT_PUBLIC_STATSIG_API_KEY)
+	})
+
+	it('passes environment config to useClientAsyncInit', () => {
+		render(
+			<FeatureFlagsProvider>
+				<span>Test</span>
+			</FeatureFlagsProvider>
+		)
+
+		const call = (useClientAsyncInit as jest.Mock).mock.calls[0]
+		const options = call[2]
+
+		expect(options.environment).toEqual({ tier: 'development' })
+	})
+})

--- a/src/common/providers/FeatureFlags/FeatureFlagsProvider.tsx
+++ b/src/common/providers/FeatureFlags/FeatureFlagsProvider.tsx
@@ -17,10 +17,13 @@ export function FeatureFlagsProvider(props: Props) {
 		process.env.NEXT_PUBLIC_STATSIG_API_KEY,
 		{},
 		{
-			plugins: [
-				new StatsigAutoCapturePlugin(),
-				new StatsigSessionReplayPlugin(),
-			],
+			plugins:
+				typeof window !== 'undefined'
+					? [
+							new StatsigAutoCapturePlugin(),
+							new StatsigSessionReplayPlugin(),
+						]
+					: [],
 			...getEnvironmentStatsigConfig(),
 		}
 	)


### PR DESCRIPTION
## Task

Proc mi na pull request z devu na master neprochazi preview build ci: 

ERROR: process "/bin/sh -c if [ -z \"${NEXT_PUBLIC_FRONTEND_URL}\" ]; then unset NEXT_PUBLIC_FRONTEND_URL; fi;   if [ -z \"${NEXT_PUBLIC_FRONTEND_HOSTNAME}\" ]; then unset NEXT_PUBLIC_FRONTEND_HOSTNAME; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_BASE_URL}\" ]; then unset NEXT_PUBLIC_PREVIEW_BASE_URL; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_MODE}\" ]; then unset NEXT_PUBLIC_PREVIEW_MODE; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_PR_NUMBER}\" ]; then unset NEXT_PUBLIC_PREVIEW_PR_NUMBER; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_PR_TITLE}\" ]; then unset NEXT_PUBLIC_PREVIEW_PR_TITLE; fi;   if [ -f yarn.lock ]; then yarn run build;   elif [ -f package-lock.json ]; then npm run build;   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build;   else echo \"Lockfile not found.\" && exit 1;   fi" did not complete successfully: exit code: 1
------
 > [builder 4/4] RUN   if [ -z "https://preview.chvalotce.cz/pr-480" ]; then unset NEXT_PUBLIC_FRONTEND_URL; fi;   if [ -z "preview.chvalotce.cz" ]; then unset NEXT_PUBLIC_FRONTEND_HOSTNAME; fi;   if [ -z "${NEXT_PUBLIC_PREVIEW_BASE_URL}" ]; then unset NEXT_PUBLIC_PREVIEW_BASE_URL; fi;   if [ -z "true" ]; then unset NEXT_PUBLIC_PREVIEW_MODE; fi;   if [ -z "480" ]; then unset NEXT_PUBLIC_PREVIEW_PR_NUMBER; fi;   if [ -z "dev to master" ]; then unset NEXT_PUBLIC_PREVIEW_PR_TITLE; fi;   if [ -f yarn.lock ]; then yarn run build;   elif [ -f package-lock.json ]; then npm run build;   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build;   else echo "Lockfile not found." && exit 1;   fi:
85.89 > 21 | 				new StatsigAutoCapturePlugin(),
85.89      | 				^
85.89   22 | 				new StatsigSessionReplayPlugin(),
85.89   23 | 			],
85.89   24 | 			...getEnvironmentStatsigConfig(),
86.10 npm notice
86.10 npm notice New major version of npm available! 10.8.2 -> 11.11.0
86.10 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.11.0
86.10 npm notice To update run: npm install -g npm@11.11.0
86.10 npm notice
------

 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 56)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 78)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 82)
Dockerfile:39
--------------------
  38 |     # When it is empty (dev/prod), unset so Next.js falls back to the .env file.
  39 | >>> RUN \
  40 | >>>   if [ -z "${NEXT_PUBLIC_FRONTEND_URL}" ]; then unset NEXT_PUBLIC_FRONTEND_URL; fi; \
  41 | >>>   if [ -z "${NEXT_PUBLIC_FRONTEND_HOSTNAME}" ]; then unset NEXT_PUBLIC_FRONTEND_HOSTNAME; fi; \
  42 | >>>   if [ -z "${NEXT_PUBLIC_PREVIEW_BASE_URL}" ]; then unset NEXT_PUBLIC_PREVIEW_BASE_URL; fi; \
  43 | >>>   if [ -z "${NEXT_PUBLIC_PREVIEW_MODE}" ]; then unset NEXT_PUBLIC_PREVIEW_MODE; fi; \
  44 | >>>   if [ -z "${NEXT_PUBLIC_PREVIEW_PR_NUMBER}" ]; then unset NEXT_PUBLIC_PREVIEW_PR_NUMBER; fi; \
  45 | >>>   if [ -z "${NEXT_PUBLIC_PREVIEW_PR_TITLE}" ]; then unset NEXT_PUBLIC_PREVIEW_PR_TITLE; fi; \
  46 | >>>   if [ -f yarn.lock ]; then yarn run build; \
  47 | >>>   elif [ -f package-lock.json ]; then npm run build; \
  48 | >>>   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
  49 | >>>   else echo "Lockfile not found." && exit 1; \
  50 | >>>   fi
  51 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c if [ -z \"${NEXT_PUBLIC_FRONTEND_URL}\" ]; then unset NEXT_PUBLIC_FRONTEND_URL; fi;   if [ -z \"${NEXT_PUBLIC_FRONTEND_HOSTNAME}\" ]; then unset NEXT_PUBLIC_FRONTEND_HOSTNAME; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_BASE_URL}\" ]; then unset NEXT_PUBLIC_PREVIEW_BASE_URL; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_MODE}\" ]; then unset NEXT_PUBLIC_PREVIEW_MODE; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_PR_NUMBER}\" ]; then unset NEXT_PUBLIC_PREVIEW_PR_NUMBER; fi;   if [ -z \"${NEXT_PUBLIC_PREVIEW_PR_TITLE}\" ]; then unset NEXT_PUBLIC_PREVIEW_PR_TITLE; fi;   if [ -f yarn.lock ]; then yarn run build;   elif [ -f package-lock.json ]; then npm run build;   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build;   else echo \"Lockfile not found.\" && exit 1;   fi" did not complete successfully: exit code: 1 ..... oprav