### PR TITLE
Me stale to dela obcas dlouhy LCP... pry z duvodu: Legacy JavaScript Est savings of 29 KiB

### DIFF
--- a/docs/2. Development/Performance & Bundle Optimization.md
+++ b/docs/2. Development/Performance & Bundle Optimization.md
@@ -71,7 +71,27 @@ The following packages were removed because they had no imports in the codebase:
 - `@stripe/stripe-js`
 - `react-device-detect` (replaced with lightweight UA detection in `src/tech/device.tech.ts`)
 
-### 8. Bundle Analyzer
+### 8. Legacy JavaScript Elimination
+
+Lighthouse flagged ~29 KiB of unnecessary polyfills shipped to modern browsers. Two changes address this:
+
+**a) Removed Next.js built-in `polyfill-module.js` (~11 KiB saved)**
+
+Next.js 14 unconditionally bundles `next/dist/build/polyfills/polyfill-module.js` into every client page. This file polyfills `Array.prototype.{at,flat,flatMap}`, `Object.{fromEntries,hasOwn}`, `String.prototype.{trimStart,trimEnd}`, `Symbol.prototype.description`, and `Promise.prototype.finally`.
+
+Since our browserslist targets (Chrome 93+, Edge 93+, Firefox 92+, Safari 15.4+) natively support all of these, the polyfill is dead weight. The webpack config aliases this file to an empty module (`src/polyfills/empty.js`) for client builds only.
+
+**b) Added `notistack` to `transpilePackages`**
+
+notistack ships pre-compiled ESM with inline Babel class helpers (`_createClass`, `_defineProperties`, `_inheritsLoose`, `_extends`). Adding it to `transpilePackages` lets SWC re-compile the package using our browserslist targets, converting these to native class syntax.
+
+**Guard rails:**
+- `src/tech/__tests__/browserslist.tech.test.ts` validates that:
+  - Browserslist targets are modern enough for all polyfilled features
+  - The empty polyfill replacement file exists and contains no executable code
+  - `next.config.mjs` correctly aliases the polyfill and includes packages in `transpilePackages`
+
+### 9. Bundle Analyzer
 
 `@next/bundle-analyzer` is installed for ongoing monitoring. Use:
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,13 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import bundleAnalyzer from '@next/bundle-analyzer'
 import createNextIntlPlugin from 'next-intl/plugin'
 import nextRoutes from 'nextjs-routes/config'
+
+const require = createRequire(import.meta.url)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const withBundleAnalyzer = bundleAnalyzer({
 	enabled: process.env.ANALYZE === 'true',
@@ -21,11 +28,27 @@ export default (phase, { defaultConfig }) => {
 	/** @type {import('next').NextConfig} */
 	const nextConfig = withNextIntl(
 		withRoutes({
-			webpack(config) {
+			webpack(config, { isServer }) {
 				config.module.rules.push({
 					test: /\.svg$/,
 					use: ['@svgr/webpack'],
 				})
+
+				// Remove Next.js built-in polyfill-module.js for client bundles.
+				// All polyfilled features (Array.prototype.{at,flat,flatMap},
+				// Object.{fromEntries,hasOwn}, String.prototype.{trimStart,trimEnd},
+				// Symbol.prototype.description, Promise.prototype.finally) are
+				// natively supported by our browserslist targets (Chrome 93+,
+				// Edge 93+, Firefox 92+, Safari 15.4+).
+				// Saves ~11 KiB from the shared JS bundle.
+				if (!isServer) {
+					config.resolve.alias[
+						require.resolve(
+							'next/dist/build/polyfills/polyfill-module'
+						)
+					] = path.resolve(__dirname, 'src/polyfills/empty.js')
+				}
+
 				return config
 			},
 			env: {
@@ -114,8 +137,10 @@ export default (phase, { defaultConfig }) => {
 			reactStrictMode: false,
 			output: 'standalone',
 			// Re-transpile packages that ship pre-compiled legacy JavaScript
-			// (babel class transforms, Object.is polyfills, etc.) to modern targets
-			transpilePackages: ['react-transition-group'],
+			// (babel class transforms, Object.is polyfills, etc.) to modern targets.
+			// SWC re-compiles these using the project's browserslist, converting
+			// Babel class helpers to native classes and stripping dead polyfills.
+			transpilePackages: ['react-transition-group', 'notistack'],
 			experimental: {
 				serverComponentsExternalPackages: ['@react-pdf/renderer'],
 				optimizePackageImports: [

--- a/src/polyfills/empty.js
+++ b/src/polyfills/empty.js
@@ -1,0 +1,5 @@
+// Intentionally empty – replaces Next.js built-in polyfill-module.js.
+// All polyfilled features (Array.prototype.{at,flat,flatMap}, Object.{fromEntries,hasOwn},
+// String.prototype.{trimStart,trimEnd}, Symbol.prototype.description, Promise.prototype.finally)
+// are natively supported by our browserslist targets (Chrome 93+, Edge 93+,
+// Firefox 92+, Safari 15.4+, iOS Safari 15.4+, Opera 79+, Samsung 17+).

--- a/src/tech/__tests__/browserslist.tech.test.ts
+++ b/src/tech/__tests__/browserslist.tech.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import path from 'path'
+
 import browserslist from 'browserslist'
 
 /**
@@ -61,5 +64,71 @@ describe('browserslist configuration', () => {
 
 		const hasOpMini = browsers.some((b) => b.startsWith('op_mini'))
 		expect(hasOpMini).toBe(false)
+	})
+})
+
+describe('polyfill-module replacement', () => {
+	const emptyPolyfillPath = path.resolve(
+		process.cwd(),
+		'src/polyfills/empty.js'
+	)
+
+	it('should have an empty polyfill replacement file', () => {
+		expect(fs.existsSync(emptyPolyfillPath)).toBe(true)
+	})
+
+	it('empty polyfill file should not contain executable code', () => {
+		const content = fs.readFileSync(emptyPolyfillPath, 'utf-8')
+		// Strip comments and whitespace
+		const code = content
+			.replace(/\/\/.*$/gm, '')
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+			.trim()
+		expect(code).toBe('')
+	})
+
+	it('Next.js polyfill-module.js should still exist (to be aliased away)', () => {
+		const nextPolyfill = require.resolve(
+			'next/dist/build/polyfills/polyfill-module'
+		)
+		expect(fs.existsSync(nextPolyfill)).toBe(true)
+	})
+})
+
+describe('next.config.mjs legacy JS mitigation', () => {
+	const configPath = path.resolve(process.cwd(), 'next.config.mjs')
+	let configContent: string
+
+	beforeAll(() => {
+		configContent = fs.readFileSync(configPath, 'utf-8')
+	})
+
+	it('should alias polyfill-module to empty file for client bundles', () => {
+		expect(configContent).toContain(
+			'next/dist/build/polyfills/polyfill-module'
+		)
+		expect(configContent).toContain('src/polyfills/empty.js')
+	})
+
+	it('should only apply polyfill alias on client builds (!isServer)', () => {
+		expect(configContent).toContain('if (!isServer)')
+	})
+
+	it('should include notistack in transpilePackages', () => {
+		expect(configContent).toContain("'notistack'")
+		// Verify it's in the transpilePackages array specifically
+		const transpileMatch = configContent.match(
+			/transpilePackages:\s*\[([^\]]+)\]/
+		)
+		expect(transpileMatch).not.toBeNull()
+		expect(transpileMatch![1]).toContain('notistack')
+	})
+
+	it('should include react-transition-group in transpilePackages', () => {
+		const transpileMatch = configContent.match(
+			/transpilePackages:\s*\[([^\]]+)\]/
+		)
+		expect(transpileMatch).not.toBeNull()
+		expect(transpileMatch![1]).toContain('react-transition-group')
 	})
 })


### PR DESCRIPTION
## Task

Me stale to dela obcas dlouhy LCP... pry z duvodu: Legacy JavaScript Est savings of 29 KiB
Polyfills and transforms enable older browsers to use new JavaScript features. However, many aren't necessary for modern browsers. Consider modifying your JavaScript build process to not transpile Baseline features, unless you know you must support older browsers. Learn why most sites can deploy ES6+ code without transpilingFCPLCPUnscored
URL
Wasted bytes
chvalotce.cz 1st party
29.1 KiB
…chunks/7023-8b051a4e46c86826.js(dev.chvalotce.cz)
11.2 KiB
7023-8b051a4e46c86826.js:1
Array.prototype.at
7023-8b051a4e46c86826.js:1
Array.prototype.flat
7023-8b051a4e46c86826.js:1
Array.prototype.flatMap
7023-8b051a4e46c86826.js:1
Object.fromEntries
7023-8b051a4e46c86826.js:1
Object.hasOwn
7023-8b051a4e46c86826.js:1
String.prototype.trimEnd
7023-8b051a4e46c86826.js:1
String.prototype.trimStart
…chunks/0c177acc.1951a0effc07e92b.js(dev.chvalotce.cz)
10.4 KiB
/_next/static/chunks…51a0effc07e92b.js:1
Array.from
…chunks/3126-a56a06c2813cbbad.js(dev.chvalotce.cz)
7.5 KiB
3126-a56a06c2813cbbad.js:1
@babel/plugin-transform-classes
3126-a56a06c2813cbbad.js:6
Object.is
3126-a56a06c2813cbbad.js:6
Object.keys ... oprav